### PR TITLE
Integrating the latest Azure Account extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,6 @@
         "opn": "^5.1.0"
     },
     "extensionDependencies": [
-        "chrisdias.vscode-azurelogin"
+        "vscode.azure-account"
     ]
 }

--- a/src/appServiceExplorer.ts
+++ b/src/appServiceExplorer.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TreeDataProvider, TreeItem, EventEmitter, Event } from 'vscode';
-import { AzureAccount } from './azureAccount';
+import { AzureAccountWrapper } from './azureAccountWrapper';
 import { NodeBase, AppServiceNode, SubscriptionNode, NotSignedInNode } from './appServiceNodes';
 
 export class AppServiceDataProvider implements TreeDataProvider<NodeBase> {
     private _onDidChangeTreeData: EventEmitter<NodeBase> = new EventEmitter<NodeBase>();
     readonly onDidChangeTreeData: Event<NodeBase> = this._onDidChangeTreeData.event;
 
-    constructor(private azureAccount: AzureAccount) {
+    constructor(private azureAccount: AzureAccountWrapper) {
         this.azureAccount.registerSessionsChangedListener(this.onSessionsChanged, this);
     }
 

--- a/src/appServiceNodes.ts
+++ b/src/appServiceNodes.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TreeDataProvider, TreeItem, TreeItemCollapsibleState, EventEmitter, Event } from 'vscode';
-import { AzureAccount } from './azureAccount';
+import { AzureAccountWrapper } from './azureAccountWrapper';
 import { SubscriptionClient, SubscriptionModels } from 'azure-arm-resource';
 import WebSiteManagementClient = require('azure-arm-website');
 import * as WebSiteModels from '../node_modules/azure-arm-website/lib/models';
@@ -25,7 +25,7 @@ export class NodeBase {
         };
     }
 
-    async getChildren(azureAccount: AzureAccount): Promise<NodeBase[]> {
+    async getChildren(azureAccount: AzureAccountWrapper): Promise<NodeBase[]> {
         return [];
     }
 }
@@ -42,7 +42,7 @@ export class SubscriptionNode extends NodeBase {
         }
     }
 
-    async getChildren(azureAccount: AzureAccount): Promise<NodeBase[]> {
+    async getChildren(azureAccount: AzureAccountWrapper): Promise<NodeBase[]> {
         if (azureAccount.signInStatus !== 'LoggedIn') {
             return [];
         }
@@ -92,25 +92,25 @@ export class AppServiceNode extends NodeBase {
         opn(uri);
     }
 
-    openInPortal(azureAccount: AzureAccount): void {
+    openInPortal(azureAccount: AzureAccountWrapper): void {
         const portalEndpoint = 'https://portal.azure.com';
         const deepLink = `${portalEndpoint}/${this.subscription.tenantId}/#resource${this.site.id}`;
         opn(deepLink);
     }
 
-    start(azureAccount: AzureAccount): Promise<void> {
+    start(azureAccount: AzureAccountWrapper): Promise<void> {
         return this.getWebSiteManagementClient(azureAccount).webApps.start(this.site.resourceGroup, this.site.name);
     }
 
-    stop(azureAccount: AzureAccount): Promise<void> {
+    stop(azureAccount: AzureAccountWrapper): Promise<void> {
         return this.getWebSiteManagementClient(azureAccount).webApps.stop(this.site.resourceGroup, this.site.name);
     }
 
-    restart(azureAccount: AzureAccount): Promise<void> {
+    restart(azureAccount: AzureAccountWrapper): Promise<void> {
         return this.getWebSiteManagementClient(azureAccount).webApps.restart(this.site.resourceGroup, this.site.name);
     }
 
-    private getWebSiteManagementClient(azureAccount: AzureAccount) {
+    private getWebSiteManagementClient(azureAccount: AzureAccountWrapper) {
         return new WebSiteManagementClient(azureAccount.getCredentialByTenantId(this.subscription.tenantId), this.subscription.subscriptionId);
     }
 }
@@ -125,7 +125,7 @@ export class NotSignedInNode extends NodeBase {
             label: this.label,
             command: {
                 title: this.label,
-                command: 'vscode-azurelogin.login'
+                command: 'azure-account.login'
             },
             collapsibleState: TreeItemCollapsibleState.None
         }

--- a/src/azure-account.api.d.ts
+++ b/src/azure-account.api.d.ts
@@ -6,14 +6,18 @@
 import { Event } from 'vscode';
 import { ServiceClientCredentials } from 'ms-rest';
 import { AzureEnvironment } from 'ms-rest-azure';
+import { SubscriptionModels, ResourceModels } from 'azure-arm-resource';
 
 export type AzureLoginStatus = 'Initializing' | 'LoggingIn' | 'LoggedIn' | 'LoggedOut';
 
-export interface AzureLogin {
+export interface AzureAccount {
 	readonly status: AzureLoginStatus;
 	readonly onStatusChanged: Event<AzureLoginStatus>;
 	readonly sessions: AzureSession[];
 	readonly onSessionsChanged: Event<void>;
+	readonly filters: AzureResourceFilter[];
+	readonly onFiltersChanged: Event<void>;
+	readonly credentials: Credentials;
 }
 
 export interface AzureSession {
@@ -21,4 +25,17 @@ export interface AzureSession {
 	readonly userId: string;
 	readonly tenantId: string;
 	readonly credentials: ServiceClientCredentials;
+}
+
+export interface AzureResourceFilter {
+	readonly session: AzureSession;
+	readonly subscription: SubscriptionModels.Subscription;
+	readonly allResourceGroups: boolean;
+	readonly resourceGroups: ResourceModels.ResourceGroup[];
+}
+
+export interface Credentials {
+	readSecret(service: string, account: string): Thenable<string | undefined>;
+	writeSecret(service: string, account: string, secret: string): Thenable<void>;
+	deleteSecret(service: string, account: string): Thenable<boolean>;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@
 import * as vscode from 'vscode';
 import { AppServiceDataProvider } from './appServiceExplorer';
 import { AppServiceNode } from './appServiceNodes';
-import { AzureAccount } from './azureAccount';
+import { AzureAccountWrapper } from './azureAccountWrapper';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Extension "Azure App Service Tools" is now active.');
@@ -16,7 +16,7 @@ export function activate(context: vscode.ExtensionContext) {
     const outputChannel = vscode.window.createOutputChannel("Azure App Service");
     context.subscriptions.push(outputChannel);
 
-    const azureAccount = new AzureAccount(context);
+    const azureAccount = new AzureAccountWrapper(context);
     const appServiceDataProvider = new AppServiceDataProvider(azureAccount);
 
     context.subscriptions.push(vscode.window.registerTreeDataProvider('azureAppService', appServiceDataProvider));


### PR DESCRIPTION
- Updated the name of the Account (previously Login) extension.
- Copied over the latest type defs.
- Renamed our own "Account" to "AccountWrapper" because the Account Extension now exposes an Account class (Previously AzureLogin).