### PR TITLE
update node d.ts file for ms-rest

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "typescript": "^2.0.3",
         "vscode": "^1.0.0",
         "mocha": "^2.3.3",
-        "@types/node": "^6.0.40",
+        "@types/node": "^7.0.10",
         "@types/mocha": "^2.2.32"
     },
     "dependencies": {


### PR DESCRIPTION
`vsce package` was complaining that the node typescript definition file was too old for the `ms-rest` and `ms-rest-azure` packages.  updating `package.json` to fix.