### PR TITLE
Move 'generate deployment script' to its own command

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
             },
             {
                 "command": "appService.DeploymentScript",
-                "title": "Generate Deployment Script",
+                "title": "Generate Azure CLI Script",
                 "category": "Azure App Service"
             },
             {
@@ -208,11 +208,6 @@
                     "group": "3_appServiceDeployCommands@2"
                 },
                 {
-                    "command": "appService.DeploymentScript",
-                    "when": "view == azureAppService && viewItem == appService",
-                    "group": "3_appServiceDeployCommands@3"
-                },
-                {
                     "command": "diagnostics.OpenLogStream",
                     "when": "view == azureAppService && viewItem == appService",
                     "group": "4_appServiceDiagnosticsCommands@1"
@@ -221,6 +216,11 @@
                     "command": "diagnostics.StopLogStream",
                     "when": "view == azureAppService && viewItem == appService",
                     "group": "4_appServiceDiagnosticsCommands@2"
+                },
+                {
+                    "command": "appService.DeploymentScript",
+                    "when": "view == azureAppService && viewItem == appService",
+                    "group": "5_appServiceMiscCommands@1"
                 },
                 {
                     "command": "appService.OpenInPortal",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "onCommand:appService.Stop",
         "onCommand:appService.Restart",
         "onCommand:appService.Delete",
+        "onCommand:appService.DeploymentScript",
         "onCommand:appService.DeployZipPackage",
         "onCommand:appService.ZipAndDeploy",
         "onCommand:deploymentSlot.SwapSlots",
@@ -91,6 +92,11 @@
             {
                 "command": "appService.Delete",
                 "title": "Delete",
+                "category": "Azure App Service"
+            },
+            {
+                "command": "appService.DeploymentScript",
+                "title": "Generate Deployment Script",
                 "category": "Azure App Service"
             },
             {
@@ -200,6 +206,11 @@
                     "command": "appService.DeployZipPackage",
                     "when": "view == azureAppService && viewItem == appService",
                     "group": "3_appServiceDeployCommands@2"
+                },
+                {
+                    "command": "appService.DeploymentScript",
+                    "when": "view == azureAppService && viewItem == appService",
+                    "group": "3_appServiceDeployCommands@3"
                 },
                 {
                     "command": "diagnostics.OpenLogStream",

--- a/src/explorer/appServiceNode.ts
+++ b/src/explorer/appServiceNode.ts
@@ -5,7 +5,7 @@
 
 import { TreeDataProvider, TreeItem, TreeItemCollapsibleState, EventEmitter, Event, workspace, window } from 'vscode';
 import { AzureAccountWrapper } from '../azureAccountWrapper';
-import { SubscriptionModels } from 'azure-arm-resource';
+import { SubscriptionModels, ResourceManagementClient, ResourceModels } from 'azure-arm-resource';
 import * as WebSiteModels from '../../node_modules/azure-arm-website/lib/models';
 import { AppServiceDataProvider } from './appServiceExplorer';
 import { NodeBase } from './nodeBase';
@@ -15,9 +15,11 @@ import { DeploymentSlotsNode } from './deploymentSlotsNode';
 import { FilesNode } from './filesNodes';
 import { WebJobsNode } from './webJobsNode';
 import { AppSettingsNode } from './appSettingsNodes';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as util from '../util';
 import * as opn from 'opn';
+import * as vscode from 'vscode';
 
 export class AppServiceNode extends SiteNodeBase {
     constructor(site: WebSiteModels.Site, subscription: SubscriptionModels.Subscription, treeDataProvider: AppServiceDataProvider, parentNode: NodeBase) {
@@ -55,5 +57,94 @@ export class AppServiceNode extends SiteNodeBase {
             new AppSettingsNode(this.site, this.subscription, treeDataProvider, this)
         ];
     }
+
+    async generateDeploymentScript(): Promise<void> {
+        const resourceClient = new ResourceManagementClient(this.azureAccount.getCredentialByTenantId(this.subscription.tenantId), this.subscription.subscriptionId);
+        const subscription = this.subscription;
+        const site = this.site;
+        const tasks = await Promise.all([
+            resourceClient.resourceGroups.get(this.site.resourceGroup),
+            this.getAppServicePlan(),
+            this.webSiteClient.webApps.getConfiguration(this.site.resourceGroup, this.site.name)
+        ]);
+        const rg = tasks[0];
+        const plan = tasks[1];
+        const siteConfig = tasks[2];
+        const script = scriptTemplate.replace('%SUBSCRIPTION_NAME%', subscription.displayName)
+            .replace('%RG_NAME%', rg.name)
+            .replace('%LOCATION%', rg.location)
+            .replace('%PLAN_NAME%', plan.name)
+            .replace('%PLAN_SKU%', plan.sku.name)
+            .replace('%SITE_NAME%', site.name)
+            .replace('%RUNTIME%', siteConfig.linuxFxVersion);
+
+        let uri: vscode.Uri;
+        if (vscode.workspace.rootPath) {
+            let count = 0;
+            const maxCount = 1024;
+
+            while (count < maxCount) {
+                uri = vscode.Uri.file(path.join(vscode.workspace.rootPath, `deploy-${site.name}${count === 0 ? '' : count.toString()}.sh`));
+                if (!vscode.workspace.textDocuments.find(doc => doc.uri.fsPath === uri.fsPath) && !fs.existsSync(uri.fsPath)) {
+                    uri = uri.with({ scheme: 'untitled' });
+                    break;
+                } else {
+                    uri = null;
+                }
+                count++;
+            }
+        }
+
+        if (uri) {
+            const doc = await vscode.workspace.openTextDocument(uri);
+            const editor = await vscode.window.showTextDocument(doc);
+            await editor.edit(editorBuilder => editorBuilder.insert(new vscode.Position(0, 0), script));
+        } else {
+            const doc = await vscode.workspace.openTextDocument({ content: script, language: 'shellscript' });
+            await vscode.window.showTextDocument(doc);
+        }
+    }
 }
 
+const scriptTemplate = 'SUBSCRIPTION="%SUBSCRIPTION_NAME%"\n\
+RESOURCEGROUP="%RG_NAME%"\n\
+LOCATION="%LOCATION%"\n\
+PLANNAME="%PLAN_NAME%"\n\
+PLANSKU="%PLAN_SKU%"\n\
+SITENAME="%SITE_NAME%"\n\
+RUNTIME="%RUNTIME%"\n\
+\n\
+# login supports device login, username/password, and service principals\n\
+# see https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest#az_login\n\
+az login\n\
+# list all of the available subscriptions\n\
+az account list -o table\n\
+# set the default subscription for subsequent operations\n\
+az account set --subscription $SUBSCRIPTION\n\
+# create a resource group for your application\n\
+az group create --name $RESOURCEGROUP --location $LOCATION\n\
+# create an appservice plan (a machine) where your site will run\n\
+az appservice plan create --name $PLANNAME --location $LOCATION --is-linux --sku $PLANSKU --resource-group $RESOURCEGROUP\n\
+# create the web application on the plan\n\
+# specify the node version your app requires\n\
+az webapp create --name $SITENAME --plan $PLANNAME --runtime $RUNTIME --resource-group $RESOURCEGROUP\n\
+\n\
+# To set up deployment from a local git repository, uncomment the following commands.\n\
+# first, set the username and password (use environment variables!)\n\
+# USERNAME=""\n\
+# PASSWORD=""\n\
+# az webapp deployment user set --user-name $USERNAME --password $PASSWORD\n\
+\n\
+# now, configure the site for deployment. in this case, we will deploy from the local git repository\n\
+# you can also configure your site to be deployed from a remote git repository or set up a CI/CD workflow\n\
+# az webapp deployment source config-local-git --name $SITENAME --resource-group $RESOURCEGROUP\n\
+\n\
+# the previous command returned the git remote to deploy to\n\
+# use this to set up a new remote named "azure"\n\
+# git remote add azure "https://$USERNAME@$SITENAME.scm.azurewebsites.net/$SITENAME.git"\n\
+# push master to deploy the site\n\
+# git push azure master\n\
+\n\
+# browse to the site\n\
+# az webapp browse --name $SITENAME --resource-group $RESOURCEGROUP\n\
+';

--- a/src/explorer/appServiceNode.ts
+++ b/src/explorer/appServiceNode.ts
@@ -62,14 +62,14 @@ export class AppServiceNode extends SiteNodeBase {
         const resourceClient = new ResourceManagementClient(this.azureAccount.getCredentialByTenantId(this.subscription.tenantId), this.subscription.subscriptionId);
         const subscription = this.subscription;
         const site = this.site;
-        const tasks = await Promise.all([
+        const taskResults = await Promise.all([
             resourceClient.resourceGroups.get(this.site.resourceGroup),
             this.getAppServicePlan(),
             this.webSiteClient.webApps.getConfiguration(this.site.resourceGroup, this.site.name)
         ]);
-        const rg = tasks[0];
-        const plan = tasks[1];
-        const siteConfig = tasks[2];
+        const rg = taskResults[0];
+        const plan = taskResults[1];
+        const siteConfig = taskResults[2];
         const script = scriptTemplate.replace('%SUBSCRIPTION_NAME%', subscription.displayName)
             .replace('%RG_NAME%', rg.name)
             .replace('%LOCATION%', rg.location)

--- a/src/explorer/siteNodeBase.ts
+++ b/src/explorer/siteNodeBase.ts
@@ -94,17 +94,7 @@ export class SiteNodeBase extends NodeBase {
 
         if (!util.isSiteDeploymentSlot(this.site)) {
             // API calls not necessary for deployment slots
-            let serverFarmArr = this.site.serverFarmId.substring(1).split('/');
-            if (serverFarmArr.length % 2 !== 0) {
-                throw new Error('Invalid web app ID.');
-            }
-            serverFarmId = {
-                subscriptions: serverFarmArr[1],
-                resourceGroups: serverFarmArr[3],
-                providers: serverFarmArr[5],
-                serverfarms: serverFarmArr[7]
-            };
-            servicePlan = await this.webSiteClient.appServicePlans.get(serverFarmId.resourceGroups, serverFarmId.serverfarms);
+            servicePlan = await this.getAppServicePlan();
         }
 
         let input = await window.showWarningMessage(`Are you sure you want to delete "${this.site.name}"?`, mOptions, 'Yes');
@@ -253,5 +243,10 @@ export class SiteNodeBase extends NodeBase {
 
     protected get webSiteClient(): WebSiteManagementClient {
         return new WebSiteManagementClient(this.azureAccount.getCredentialByTenantId(this.subscription.tenantId), this.subscription.subscriptionId);
+    }
+
+    protected async getAppServicePlan(): Promise<WebSiteModels.AppServicePlan> {
+        const serverFarmId = util.parseAzureResourceId(this.site.serverFarmId.toLowerCase());
+        return await this.webSiteClient.appServicePlans.get(serverFarmId.resourcegroups, serverFarmId.serverfarms);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,7 +109,6 @@ export function activate(context: vscode.ExtensionContext) {
 
                 }
                 throw err;
-
             }
         }
     });
@@ -157,7 +156,6 @@ export function activate(context: vscode.ExtensionContext) {
                     } catch {
                         outputChannel.appendLine(err.message);
                     }
-
                 }
             }
         }
@@ -165,7 +163,7 @@ export function activate(context: vscode.ExtensionContext) {
     initAsyncCommand(context, 'appService.DeploymentScript', async (node: AppServiceNode) => {
         if (node) {
             await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, p => {
-                p.report({ message: 'Generating deployment script...' });
+                p.report({ message: 'Generating script...' });
                 return node.generateDeploymentScript();
             });
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,6 +162,14 @@ export function activate(context: vscode.ExtensionContext) {
             }
         }
     });
+    initAsyncCommand(context, 'appService.DeploymentScript', async (node: AppServiceNode) => {
+        if (node) {
+            await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, p => {
+                p.report({ message: 'Generating deployment script...' });
+                return node.generateDeploymentScript();
+            });
+        }
+    });
     initAsyncCommand(context, 'deploymentSlot.SwapSlots', async (node: DeploymentSlotNode) => {
         if (node) {
             await node.swapDeploymentSlots(outputChannel);

--- a/src/util.ts
+++ b/src/util.ts
@@ -106,3 +106,32 @@ export function errToString(error: any): string {
 
     return error.toString();
 }
+
+// Resource ID
+export function parseAzureResourceId(resourceId: string): { [key: string]: string } {
+    const invalidIdErr = new Error('Invalid web app ID.');
+    const result = {};
+
+    if (!resourceId || resourceId.length < 2 || resourceId.charAt(0) !== '/') {
+        throw invalidIdErr;
+    }
+
+    const parts = resourceId.substring(1).split('/');
+
+    if (parts.length % 2 !== 0) {
+        throw invalidIdErr;
+    }
+
+    for (let i = 0; i < parts.length; i += 2) {
+        const key = parts[i];
+        const value = parts[i + 1];
+
+        if (key === '' || value === '') {
+            throw invalidIdErr;
+        }
+
+        result[parts[i]] = parts[i + 1];
+    }
+
+    return result;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -130,7 +130,7 @@ export function parseAzureResourceId(resourceId: string): { [key: string]: strin
             throw invalidIdErr;
         }
 
-        result[parts[i]] = parts[i + 1];
+        result[key] = value;
     }
 
     return result;

--- a/src/webAppCreator.ts
+++ b/src/webAppCreator.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
-import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { AzureAccountWrapper } from './azureAccountWrapper';
 import { WizardBase, WizardResult, WizardStep, SubscriptionStepBase, QuickPickItemWithData } from './wizard';
@@ -21,7 +19,6 @@ export class WebAppCreator extends WizardBase {
         this.steps.push(new ResourceGroupStep(this, azureAccount));
         this.steps.push(new AppServicePlanStep(this, azureAccount));
         this.steps.push(new WebsiteStep(this, azureAccount));
-        this.steps.push(new ShellScriptStep(this, azureAccount));
     }
 
     async run(promptOnly = false): Promise<WizardResult> {
@@ -518,97 +515,7 @@ class WebsiteStep extends WebAppCreatorStepBase {
     }
 }
 
-class ShellScriptStep extends WebAppCreatorStepBase {
-    constructor(wizard: WizardBase, azureAccount: AzureAccountWrapper) {
-        super(wizard, 'Create Web App', azureAccount);
-    }
-
-    async execute(): Promise<void> {
-        const subscription = this.getSelectedSubscription();
-        const rg = this.getSelectedResourceGroup();
-        const plan = this.getSelectedAppServicePlan();
-        const site = this.getWebSite();
-
-        const script = scriptTemplate.replace('%SUBSCRIPTION_NAME%', subscription.displayName)
-            .replace('%RG_NAME%', rg.name)
-            .replace('%LOCATION%', rg.location)
-            .replace('%PLAN_NAME%', plan.name)
-            .replace('%PLAN_SKU%', plan.sku.name)
-            .replace('%SITE_NAME%', site.name)
-            .replace('%RUNTIME%', site.siteConfig.linuxFxVersion);
-
-        let uri: vscode.Uri;
-        if (vscode.workspace.rootPath) {
-            let count = 0;
-            const maxCount = 1024;
-
-            while (count < maxCount) {
-                uri = vscode.Uri.file(path.join(vscode.workspace.rootPath, `deploy-${site.name}${count === 0 ? '' : count.toString()}.sh`));
-                if (!vscode.workspace.textDocuments.find(doc => doc.uri.fsPath === uri.fsPath) && !fs.existsSync(uri.fsPath)) {
-                    uri = uri.with({ scheme: 'untitled' });
-                    break;
-                } else {
-                    uri = null;
-                }
-                count++;
-            }
-        }
-
-        if (uri) {
-            const doc = await vscode.workspace.openTextDocument(uri);
-            const editor = await vscode.window.showTextDocument(doc);
-            await editor.edit(editorBuilder => editorBuilder.insert(new vscode.Position(0, 0), script));
-        } else {
-            const doc = await vscode.workspace.openTextDocument({ content: script, language: 'shellscript' });
-            await vscode.window.showTextDocument(doc);
-        }
-    }
-}
-
 interface LinuxRuntimeStack {
     name: string;
     displayName: string;
 }
-
-const scriptTemplate = 'SUBSCRIPTION="%SUBSCRIPTION_NAME%"\n\
-RESOURCEGROUP="%RG_NAME%"\n\
-LOCATION="%LOCATION%"\n\
-PLANNAME="%PLAN_NAME%"\n\
-PLANSKU="%PLAN_SKU%"\n\
-SITENAME="%SITE_NAME%"\n\
-RUNTIME="%RUNTIME%"\n\
-\n\
-# login supports device login, username/password, and service principals\n\
-# see https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest#az_login\n\
-az login\n\
-# list all of the available subscriptions\n\
-az account list -o table\n\
-# set the default subscription for subsequent operations\n\
-az account set --subscription $SUBSCRIPTION\n\
-# create a resource group for your application\n\
-az group create --name $RESOURCEGROUP --location $LOCATION\n\
-# create an appservice plan (a machine) where your site will run\n\
-az appservice plan create --name $PLANNAME --location $LOCATION --is-linux --sku $PLANSKU --resource-group $RESOURCEGROUP\n\
-# create the web application on the plan\n\
-# specify the node version your app requires\n\
-az webapp create --name $SITENAME --plan $PLANNAME --runtime $RUNTIME --resource-group $RESOURCEGROUP\n\
-\n\
-# To set up deployment from a local git repository, uncomment the following commands.\n\
-# first, set the username and password (use environment variables!)\n\
-# USERNAME=""\n\
-# PASSWORD=""\n\
-# az webapp deployment user set --user-name $USERNAME --password $PASSWORD\n\
-\n\
-# now, configure the site for deployment. in this case, we will deploy from the local git repository\n\
-# you can also configure your site to be deployed from a remote git repository or set up a CI/CD workflow\n\
-# az webapp deployment source config-local-git --name $SITENAME --resource-group $RESOURCEGROUP\n\
-\n\
-# the previous command returned the git remote to deploy to\n\
-# use this to set up a new remote named "azure"\n\
-# git remote add azure "https://$USERNAME@$SITENAME.scm.azurewebsites.net/$SITENAME.git"\n\
-# push master to deploy the site\n\
-# git push azure master\n\
-\n\
-# browse to the site\n\
-# az webapp browse --name $SITENAME --resource-group $RESOURCEGROUP\n\
-';


### PR DESCRIPTION
Fix #98 

Instead of popping up the script at the end of the create wizard, use a context menu to create a deployment script using the selected web app as template.

![image](https://user-images.githubusercontent.com/15821566/31411546-d319dcce-adc6-11e7-9a71-06b77df769b5.png)
