### PR TITLE
Improvements to App Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "onCommand:deploymentSlot.SwapSlots",
         "onCommand:appSettings.Add",
         "onCommand:appSettings.Edit",
+        "onCommand:appSettings.Rename",
         "onCommand:appSettings.Delete",
         "onCommand:diagnostics.OpenLogStream",
         "onCommand:diagnostics.StopLogStream",
@@ -121,12 +122,17 @@
             },
             {
                 "command": "appSettings.Edit",
-                "title": "Edit Setting...",
+                "title": "Edit...",
+                "category": "Azure App Service"
+            },
+            {
+                "command": "appSettings.Rename",
+                "title": "Rename...",
                 "category": "Azure App Service"
             },
             {
                 "command": "appSettings.Delete",
-                "title": "Delete Setting",
+                "title": "Delete",
                 "category": "Azure App Service"
             },
             {
@@ -313,9 +319,14 @@
                     "group": "1_appSettingItemEdit@1"
                 },
                 {
-                    "command": "appSettings.Delete",
+                    "command": "appSettings.Rename",
                     "when": "view == azureAppService && viewItem == applicationSettingItem",
                     "group": "1_appSettingItemEdit@2"
+                },
+                {
+                    "command": "appSettings.Delete",
+                    "when": "view == azureAppService && viewItem == applicationSettingItem",
+                    "group": "1_appSettingItemEdit@3"
                 }
             ],
             "explorer/context": [

--- a/src/explorer/appSettingsNodes.ts
+++ b/src/explorer/appSettingsNodes.ts
@@ -153,7 +153,7 @@ export class AppSettingNode extends NodeBase {
         private value: string,
         treeDataProvider: AppServiceDataProvider,
         parentNode: NodeBase) {
-        super(`${key} : ${value}`, treeDataProvider, parentNode);
+        super(`${key}=${value}`, treeDataProvider, parentNode);
     }
 
     getTreeItem(): TreeItem {

--- a/src/explorer/appSettingsNodes.ts
+++ b/src/explorer/appSettingsNodes.ts
@@ -175,7 +175,7 @@ export class AppSettingNode extends NodeBase {
             value: this.value
         });
 
-        if (!newValue) {
+        if (newValue === undefined) {
             return;
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,6 +183,11 @@ export function activate(context: vscode.ExtensionContext) {
             await node.edit();
         }
     });
+    initAsyncCommand(context, 'appSettings.Rename', async (node: AppSettingNode) => {
+        if (node) {
+            await node.rename();
+        }
+    });
     initAsyncCommand(context, 'appSettings.Delete', async (node: AppSettingNode) => {
         if (node) {
             await node.delete();


### PR DESCRIPTION
Fix #94  (parts of it)

Use "=" instead of ":" to separate key and values. Now it aligns with OS behavior when you list environment variables from command line.

![image](https://user-images.githubusercontent.com/15821566/31473957-97c94ce0-aeac-11e7-911c-cb0c22ee0425.png)

Separate commands for editing Key and Value.

![image](https://user-images.githubusercontent.com/15821566/31473981-b68591c0-aeac-11e7-9a3a-02be5aee25d7.png)
