### PR TITLE
Remove error output from wizard onError

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,12 +216,12 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
             } else {
                 properties.result = 'Failed';
                 errorData = new ErrorData(err);
-                output.appendLine(errorData.message);
+                output.appendLine(`Error: ${errorData.message}`);
                 if (errorData.message.includes('\n')) {
                     output.show();
                     vscode.window.showErrorMessage('An error has occured. Check output window for more details.');
                 } else {
-                    vscode.window.showErrorMessage(`Error: ${errorData.message}`);
+                    vscode.window.showErrorMessage(errorData.message);
                 }
 
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,7 +221,7 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
                     output.show();
                     vscode.window.showErrorMessage('An error has occured. Check output window for more details.');
                 } else {
-                    vscode.window.showErrorMessage(errorData.message);
+                    vscode.window.showErrorMessage(`Error: ${errorData.message}`);
                 }
 
             }

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -100,8 +100,6 @@ export abstract class WizardBase {
             throw err;
         }
 
-        this.writeline(`Error: ${err.message}`);
-        this.writeline('');
         throw new WizardFailedError(err, step.telemetryStepTitle, step.stepIndex);
     }
 


### PR DESCRIPTION
Fixes #146 
Added Error: prefix to output messages because it is not always immediately obvious that the outputted message is an error.