### PR TITLE
Remove Close button on warningMessages

### DIFF
--- a/src/explorer/AppSettingsTreeItem.ts
+++ b/src/explorer/AppSettingsTreeItem.ts
@@ -187,8 +187,9 @@ export class AppSettingTreeItem implements IAzureTreeItem {
     }
 
     public async deleteTreeItem(node: IAzureNode): Promise<IAzureTreeItem> {
-        const okayAction = 'Delete';
-        const result = await vscode.window.showWarningMessage(`Are you sure you want to delete setting "${this.key}"?`, okayAction);
+        const okayAction: vscode.MessageItem = { title: 'Delete' };
+        const cancelAction: vscode.MessageItem = { title: 'Cancel', isCloseAffordance: true };
+        const result = await vscode.window.showWarningMessage(`Are you sure you want to delete setting "${this.key}"?`, okayAction, cancelAction);
 
         if (result === okayAction) {
             await (<AppSettingsTreeItem>node.parent.treeItem).deleteSettingItem(nodeUtils.getWebSiteClient(node), this.key);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -190,13 +190,14 @@ export function activate(context: vscode.ExtensionContext): void {
         }
 
         const client: WebSiteManagementClient = nodeUtils.getWebSiteClient(node);
-        const enableButton = 'Yes';
+        const enableButton: vscode.MessageItem = { title: 'Yes' };
+        const notNowButton: vscode.MessageItem = { title: 'Not Now', isCloseAffordance: true };
         const isEnabled = await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, p => {
             p.report({ message: 'Checking container diagnostics settings...' });
             return node.treeItem.isHttpLogsEnabled(client);
         });
 
-        if (!isEnabled && enableButton === await vscode.window.showWarningMessage('Do you want to enable logging and restart this container?', enableButton)) {
+        if (!isEnabled && enableButton === await vscode.window.showWarningMessage('Do you want to enable logging and restart this container?', enableButton, notNowButton)) {
             outputChannel.show();
             outputChannel.appendLine(`Enabling Logging for "${node.treeItem.site.name}"...`);
             await node.treeItem.enableHttpLogs(client);


### PR DESCRIPTION
Fixes #185 

I used "Not Now" for the log streaming prompt as regardless of which button you click, log streaming will start, but will not be "enabled" and the container won't be restarted.