### PR TITLE
Clear out the glyphs after a debug session termination.

### DIFF
--- a/src/diagnostics/LogPointsManager.ts
+++ b/src/diagnostics/LogPointsManager.ts
@@ -68,6 +68,12 @@ class DebugSessionManager {
         logpointsCollection.updateTextEditorDecroration();
     }
 
+    public removeLogpointGlyphsFromDocument(documentUri: vscode.Uri): void {
+        const logpointsCollection = this.getLogpointCollectionForDocument(documentUri);
+        logpointsCollection.clearRegistry();
+        logpointsCollection.updateTextEditorDecroration();
+    }
+
     public async addLogpoint(scriptId: string, lineNumber: number, columnNumber: number): Promise<ILogpoint> {
         const expression = await vscode.window.showInputBox({
             ignoreFocusOut: true,
@@ -125,6 +131,7 @@ export class LogPointsManager extends vscode.Disposable {
         });
 
         vscode.debug.onDidTerminateDebugSession((debugSession) => {
+            this.onDebugSessionClose(debugSession);
             delete this._debugSessionManagerMapping[debugSession.id];
         });
 
@@ -158,7 +165,7 @@ export class LogPointsManager extends vscode.Disposable {
         const debugSessionManager = this._debugSessionManagerMapping[params.vscodeDebugSessionId];
 
         if (!debugSessionManager) {
-            vscode.window.showErrorMessage(`Cannot find debug session with id ${params.vscodeDebugSessionId}`);
+            vscode.window.showErrorMessage(`The debug session associated with this file has expired. Please close this file and open it again from LOADED SCRIPTS explorer of an active logpoints session. More details can be found here - http://aka.ms/logpoints#setting-up-logpoints`);
             return false;
         }
 
@@ -196,6 +203,23 @@ export class LogPointsManager extends vscode.Disposable {
         }
 
         debugSessionManager.recoverLogpoints(documentUri);
+    }
+
+    private onDebugSessionClose(debugSession: vscode.DebugSession): void {
+
+        const debugSessionManager = this._debugSessionManagerMapping[debugSession.id];
+
+        if (!debugSessionManager) {
+            // If debugSessionManager does not exist, it might have been handled already.
+            return;
+        }
+
+        if (!vscode.window.activeTextEditor) {
+            return;
+        }
+        const documentUri = vscode.window.activeTextEditor.document.uri;
+
+        debugSessionManager.removeLogpointGlyphsFromDocument(documentUri);
     }
 
     // tslint:disable-next-line:no-empty

--- a/src/diagnostics/logPointsSessionWizard.ts
+++ b/src/diagnostics/logPointsSessionWizard.ts
@@ -134,7 +134,7 @@ class PromptSlotSelection extends WizardStep {
         // if there is only one slot, just use that one and don't prompt for user selection.
         if (deploymentSlots.length === 1) {
             this._wizard.selectedDeploymentSlot = deploymentSlots[0];
-            this._wizard.writeline(`Automatically selected deployment solt ${this._wizard.selectedDeploymentSlot.name}.`);
+            this._wizard.writeline(`Automatically selected deployment slot ${this._wizard.selectedDeploymentSlot.name}.`);
             return;
         }
 

--- a/src/diagnostics/structs/LogpointsCollection.ts
+++ b/src/diagnostics/structs/LogpointsCollection.ts
@@ -9,7 +9,7 @@ export class LogpointsCollection {
     private _logpointRegistry: { [line: number]: ILogpoint };
 
     public constructor(private _documentUri: vscode.Uri) {
-        this._logpointRegistry = {};
+        this.clearRegistry();
     }
 
     public get documentUri(): vscode.Uri {
@@ -40,6 +40,10 @@ export class LogpointsCollection {
     public getLogpoints(): ILogpoint[] {
         // tslint:disable-next-line:no-any
         return (<any>Object).values(this._logpointRegistry);
+    }
+
+    public clearRegistry(): void {
+        this._logpointRegistry = {};
     }
 
     public updateTextEditorDecroration(): void {


### PR DESCRIPTION
And also improve the error message given when user try to set a logpoint to an inactive document.