### PR TITLE
Send an activation ping before we start th logpoints session.

### DIFF
--- a/src/diagnostics/LogPointsSessionWizard.ts
+++ b/src/diagnostics/LogPointsSessionWizard.ts
@@ -9,6 +9,7 @@ import WebSiteManagementClient = require('azure-arm-website');
 
 import { IAzureNode } from 'vscode-azureextensionui';
 import { SiteTreeItem } from '../explorer/SiteTreeItem';
+import { ActivateSite } from './wizardSteps/ActivateSite';
 import { CheckLogStreamAvailability } from './wizardSteps/CheckLogStreamAvailability';
 import { EligibilityCheck } from './wizardSteps/EligibilityCheck';
 import { GetUnoccupiedInstance } from './wizardSteps/GetUnoccupiedInstance';
@@ -69,6 +70,7 @@ export class LogPointsSessionWizard extends WizardBase {
             this.steps.push(new PromptSlotSelection(this, this.site));
         }
 
+        this.steps.push(new ActivateSite(this));
         this.steps.push(new GetUnoccupiedInstance(this, logPointsDebuggerClient));
         this.steps.push(new PickProcessStep(this, logPointsDebuggerClient));
         this.steps.push(new SessionAttachStep(this, logPointsDebuggerClient));

--- a/src/diagnostics/wizardSteps/ActivateSite.ts
+++ b/src/diagnostics/wizardSteps/ActivateSite.ts
@@ -1,0 +1,28 @@
+import { Site } from 'azure-arm-website/lib/models';
+import * as request from "request";
+import { WizardStep } from '../../wizard';
+import { LogPointsSessionWizard } from '../LogPointsSessionWizard';
+
+export class ActivateSite extends WizardStep {
+    constructor(private _wizard: LogPointsSessionWizard) {
+        super(_wizard, 'Send an activation ping to the site root URL.');
+    }
+
+    public async prompt(): Promise<void> {
+        const site = this._wizard.selectedDeploymentSlot;
+
+        if (!site) {
+            throw new Error("There is no pre-selected deployment slot or site.");
+        }
+
+        const siteRootUrl = this.getSiteRootUrl(site);
+
+        // Intentionally ignore the response.
+        request(siteRootUrl);
+    }
+
+    private getSiteRootUrl(site: Site): string {
+        // tslint:disable-next-line:no-http-string
+        return `http://${site.defaultHostName}`;
+    }
+}

--- a/src/diagnostics/wizardSteps/PickProcessStep.ts
+++ b/src/diagnostics/wizardSteps/PickProcessStep.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { UserCancelledError } from 'vscode-azureextensionui';
 import * as util from '../../util';
+import { callWithTimeout, DEFAULT_TIMEOUT } from '../../utils/logpointsUtil';
 import { WizardStep } from '../../wizard';
 import { ILogPointsDebuggerClient } from '../logPointsClient';
 import { LogPointsSessionWizard } from '../LogPointsSessionWizard';
@@ -24,7 +25,11 @@ export class PickProcessStep extends WizardStep {
             p.report({ message: message });
             this._wizard.writeline(message);
             const siteName = util.extractSiteName(selectedSlot) + (util.isSiteDeploymentSlot(selectedSlot) ? `-util.extractDeploymentSlotName(selectedSlot)` : '');
-            result = await this._logPointsDebuggerClient.enumerateProcesses(siteName, instance.name, publishCredential);
+            result = await callWithTimeout(
+                () => {
+                    return this._logPointsDebuggerClient.enumerateProcesses(siteName, instance.name, publishCredential);
+                },
+                DEFAULT_TIMEOUT);
         });
 
         if (!result.isSuccessful() || result.json.data.length === 0) {

--- a/src/diagnostics/wizardSteps/PromptSlotSelection.ts
+++ b/src/diagnostics/wizardSteps/PromptSlotSelection.ts
@@ -2,6 +2,7 @@ import { Site } from 'azure-arm-website/lib/models';
 import * as vscode from 'vscode';
 import { UserCancelledError } from 'vscode-azureextensionui';
 import * as util from '../../util';
+import { callWithTimeout, DEFAULT_TIMEOUT } from '../../utils/logpointsUtil';
 import { WizardStep } from '../../wizard';
 import { LogPointsSessionWizard } from '../LogPointsSessionWizard';
 
@@ -57,7 +58,11 @@ export class PromptSlotSelection extends WizardStep {
      */
     private async getDeploymentSlots(): Promise<Site[]> {
         const client = this._wizard.websiteManagementClient;
-        const allDeploymentSlots = await client.webApps.listByResourceGroup(this.site.resourceGroup, { includeSlots: true });
+        const allDeploymentSlots = await callWithTimeout(
+            () => {
+                return client.webApps.listByResourceGroup(this.site.resourceGroup, { includeSlots: true });
+            },
+            DEFAULT_TIMEOUT);
         return allDeploymentSlots.filter((slot) => {
             return slot.repositorySiteName === this.site.name;
         });

--- a/src/diagnostics/wizardSteps/SessionAttachStep.ts
+++ b/src/diagnostics/wizardSteps/SessionAttachStep.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as util from '../../util';
+import { callWithTimeout, DEFAULT_TIMEOUT } from '../../utils/logpointsUtil';
 import { WizardStep } from '../../wizard';
 import { ILogPointsDebuggerClient } from '../logPointsClient';
 import { LogPointsSessionWizard } from '../LogPointsSessionWizard';
@@ -26,7 +27,11 @@ export class SessionAttachStep extends WizardStep {
             const message = `Attach debugging to session ${this._wizard.sessionId}...`;
             p.report({ message: message });
             this._wizard.writeline(message);
-            result = await this._logPointsDebuggerClient.attachProcess(siteName, instance.name, publishCredential, requestData);
+            result = await callWithTimeout(
+                () => {
+                    return this._logPointsDebuggerClient.attachProcess(siteName, instance.name, publishCredential, requestData);
+                },
+                DEFAULT_TIMEOUT);
         });
 
         if (result.isSuccessful()) {

--- a/src/utils/logpointsUtil.ts
+++ b/src/utils/logpointsUtil.ts
@@ -1,0 +1,24 @@
+import { setTimeout } from "timers";
+
+export const DEFAULT_TIMEOUT = 20000;
+// tslint:disable-next-line:export-name
+// tslint:disable-next-line:no-any
+export function callWithTimeout<T>(proc: (...args: any[]) => Promise<T>, timeout: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(
+            () => {
+                reject(new Error(`Invocation timed out after ${timeout} milliseconds.`));
+            },
+            timeout
+        );
+
+        if (!proc) {
+            reject("Procedure cannot be null");
+        }
+
+        proc().then((result) => {
+            clearTimeout(timer);
+            resolve(result);
+        });
+    });
+}


### PR DESCRIPTION
Also add a timeout guard in case the Kudu/ARM calls takes too long due to inactivity of the app service.