### PR TITLE
Zip deploy configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,6 +477,16 @@
                         "azurenodelogpoints.azurecr.io/azure-nodejs-logpoints"
                     ],
                     "description": "The supported Docker images that logpoints feature can run with."
+                },
+                "zipDeploy.globPattern": {
+                    "type": "string",
+                    "default": "**/*",
+                    "description": "Defines which files in the workspace to deploy. This applies to Zip deploy only, has no effect on other deployment methods."
+                },
+                "zipDeploy.ignorePattern": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Defines which files in the workspace to ignore for Zip deploy. This applies to Zip deploy only, has no effect on other deployment methods."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -585,7 +585,7 @@
         "opn": "^5.1.0",
         "request": "^2.83.0",
         "simple-git": "^1.77.0",
-        "vscode-azureappservice": "~0.7.0",
+        "vscode-azureappservice": "~0.8.0",
         "vscode-azureextensionui": "~0.3.0",
         "vscode-debugadapter": "^1.24.0",
         "vscode-debugprotocol": "^1.24.0",

--- a/package.json
+++ b/package.json
@@ -478,12 +478,12 @@
                     ],
                     "description": "The supported Docker images that logpoints feature can run with."
                 },
-                "zipDeploy.globPattern": {
+                "appService.zipGlobPattern": {
                     "type": "string",
                     "default": "**/*",
                     "description": "Defines which files in the workspace to deploy. This applies to Zip deploy only, has no effect on other deployment methods."
                 },
-                "zipDeploy.ignorePattern": {
+                "appService.zipIgnorePattern": {
                     "type": "string",
                     "default": "",
                     "description": "Defines which files in the workspace to ignore for Zip deploy. This applies to Zip deploy only, has no effect on other deployment methods."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,7 +137,7 @@ export function activate(context: vscode.ExtensionContext): void {
         if (await vscode.window.showInformationMessage('Deploy to web app?', yesButton, noButton)) {
             const fsPath = (await util.showWorkspaceFoldersQuickPick("Select the folder to deploy")).uri.fsPath;
             const client = nodeUtils.getWebSiteClient(createdApp);
-            await createdApp.treeItem.siteWrapper.deploy(fsPath, client, outputChannel, false);
+            await createdApp.treeItem.siteWrapper.deploy(fsPath, client, outputChannel, 'appService', false);
         }
     });
     initAsyncCommand(context, 'appService.Deploy', async (target?: vscode.Uri | IAzureNode<WebAppTreeItem> | undefined) => {
@@ -201,7 +201,7 @@ export function activate(context: vscode.ExtensionContext): void {
         if (await vscode.window.showInformationMessage('Deploy to deployment slot?', yesButton, noButton)) {
             const fsPath = (await util.showWorkspaceFoldersQuickPick("Select the folder to deploy")).uri.fsPath;
             const client = nodeUtils.getWebSiteClient(createdSlot);
-            await createdSlot.treeItem.siteWrapper.deploy(fsPath, client, outputChannel, false);
+            await createdSlot.treeItem.siteWrapper.deploy(fsPath, client, outputChannel, 'appService', false);
         }
     });
     initAsyncCommand(context, 'deploymentSlot.SwapSlots', async (node: IAzureNode<DeploymentSlotTreeItem>) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,7 +143,7 @@ export function activate(context: vscode.ExtensionContext): void {
         }
         const client = nodeUtils.getWebSiteClient(node);
         try {
-            await node.treeItem.siteWrapper.deploy(fsPath, client, outputChannel);
+            await node.treeItem.siteWrapper.deploy(fsPath, client, outputChannel, 'appService');
         } catch (err) {
             if (err instanceof UserCancelledError) {
                 throw err;


### PR DESCRIPTION
Fix #176 

Now you can add glob patterns to settings to specify what files to ignore when doing Zip deploy.

This doesn't affect local Git deploy since that is governed by .gitignore file.

The actual code implementation is here:
https://github.com/Microsoft/vscode-azuretools/pull/44/files