### PR TITLE
Automatically open logstream of a site/deploymentSlot when launch debug session.

### DIFF
--- a/src/diagnostics/LogPointsDebugAdapter.ts
+++ b/src/diagnostics/LogPointsDebugAdapter.ts
@@ -84,6 +84,8 @@ export class LogPointsDebugAdapter extends LoggingDebugSession {
         this.sendResponse(response);
 
         this.getLoadedScripts();
+
+        this.sendSessionStartedEvent();
     }
 
     // tslint:disable-next-line:no-any
@@ -191,6 +193,10 @@ export class LogPointsDebugAdapter extends LoggingDebugSession {
             });
         }
 
+    }
+
+    private sendSessionStartedEvent(): void {
+        this.sendEvent(new Event('sessionStarted'));
     }
 
     private getPublishCredential(): User {

--- a/src/diagnostics/LogPointsManager.ts
+++ b/src/diagnostics/LogPointsManager.ts
@@ -1,6 +1,7 @@
 import * as WebSiteModels from 'azure-arm-website/lib/models';
 import * as util from 'util';
 import * as vscode from 'vscode';
+import { DebugSessionCustomEvent } from 'vscode';
 import * as appserviceUtil from '../util';
 import { RemoteScriptSchema } from './remoteScriptDocumentProvider';
 import { IDebugSessionMetaData } from './structs/IDebugSessionMetaData';
@@ -145,6 +146,7 @@ class DebugSessionManager {
 
 export class LogPointsManager extends vscode.Disposable {
     private _debugSessionManagerMapping: { [key: string]: DebugSessionManager };
+    private _siteStreamingLogOutputChannelMapping: { [siteName: string]: vscode.OutputChannel };
 
     constructor(private _outputChannel: vscode.OutputChannel) {
         super(() => {
@@ -152,6 +154,7 @@ export class LogPointsManager extends vscode.Disposable {
         });
 
         this._debugSessionManagerMapping = {};
+        this._siteStreamingLogOutputChannelMapping = {};
         this.initialize();
     }
 
@@ -166,10 +169,18 @@ export class LogPointsManager extends vscode.Disposable {
         vscode.debug.onDidTerminateDebugSession((debugSession) => {
             this.onDebugSessionClose(debugSession);
             delete this._debugSessionManagerMapping[debugSession.id];
+            const siteName = debugSession.name;
+            if (this._siteStreamingLogOutputChannelMapping[siteName]) {
+                delete this._siteStreamingLogOutputChannelMapping[siteName];
+            }
         });
 
         vscode.window.onDidChangeActiveTextEditor((event: vscode.TextEditor) => {
             this.onActiveEditorChange(event);
+        });
+
+        vscode.debug.onDidReceiveDebugSessionCustomEvent((event: DebugSessionCustomEvent) => {
+            this.onDebugSessionCustomEvent(event);
         });
     }
 
@@ -227,6 +238,11 @@ export class LogPointsManager extends vscode.Disposable {
         this._outputChannel.appendLine("The logpoints session has terminated because the App Service is stopped or restarted.");
     }
 
+    public onStreamingLogOutputChannelCreated(site: WebSiteModels.Site, outputChannel: vscode.OutputChannel): void {
+        const siteName = appserviceUtil.extractSiteScmSubDomainName(site);
+        this._siteStreamingLogOutputChannelMapping[siteName] = outputChannel;
+    }
+
     private onActiveEditorChange(activeEditor: vscode.TextEditor): void {
         if (!activeEditor) {
             return;
@@ -266,10 +282,25 @@ export class LogPointsManager extends vscode.Disposable {
         debugSessionManager.removeLogpointGlyphsFromDocument(documentUri);
     }
 
+    private onDebugSessionCustomEvent(e: DebugSessionCustomEvent): void {
+        if (e.event === 'sessionStarted') {
+            const siteName = e.session.name;
+
+            const streamingLogOutputChannel = this._siteStreamingLogOutputChannelMapping[siteName];
+
+            if (streamingLogOutputChannel) {
+                streamingLogOutputChannel.show();
+            } else {
+                this._outputChannel.show();
+                this._outputChannel.appendLine('Cannot find streaming log output channel.');
+            }
+        }
+    }
+
     private async findDebugSessionManagerBySite(site: WebSiteModels.Site): Promise<DebugSessionManager> {
         let matchedDebugSessionManager: DebugSessionManager = null;
 
-        const siteName = appserviceUtil.extractSiteName(site) + (appserviceUtil.isSiteDeploymentSlot(site) ? `-${appserviceUtil.extractDeploymentSlotName(site)}` : '');
+        const siteName = appserviceUtil.extractSiteScmSubDomainName(site);
 
         const debugSessionManagers = Object.keys(this._debugSessionManagerMapping).map(
             (key) => { return this._debugSessionManagerMapping[key]; });

--- a/src/diagnostics/structs/IAttachProcessResponse.ts
+++ b/src/diagnostics/structs/IAttachProcessResponse.ts
@@ -1,4 +1,9 @@
 export interface IAttachProcessResponse {
+    error?: {
+        // tslint:disable-next-line:no-reserved-keywords
+        "type": string,
+        message: string
+    };
     data: {
         debugeeId: string;
     };

--- a/src/diagnostics/wizardSteps/GetUnoccupiedInstance.ts
+++ b/src/diagnostics/wizardSteps/GetUnoccupiedInstance.ts
@@ -35,7 +35,7 @@ export class GetUnoccupiedInstance extends WizardStep {
             return a.name.localeCompare(b.name);
         });
 
-        const siteName = util.extractSiteName(selectedSlot) + (util.isSiteDeploymentSlot(selectedSlot) ? `-${util.extractDeploymentSlotName(selectedSlot)}` : '');
+        const siteName = util.extractSiteScmSubDomainName(selectedSlot);
 
         for (const instance of instances) {
             let result: CommandRunResult<IStartSessionResponse>;

--- a/src/diagnostics/wizardSteps/PickProcessStep.ts
+++ b/src/diagnostics/wizardSteps/PickProcessStep.ts
@@ -24,7 +24,7 @@ export class PickProcessStep extends WizardStep {
             const message = `Enumerate node processes from instance ${instance.name}...`;
             p.report({ message: message });
             this._wizard.writeline(message);
-            const siteName = util.extractSiteName(selectedSlot) + (util.isSiteDeploymentSlot(selectedSlot) ? `-util.extractDeploymentSlotName(selectedSlot)` : '');
+            const siteName = util.extractSiteScmSubDomainName(selectedSlot);
             result = await callWithTimeout(
                 () => {
                     return this._logPointsDebuggerClient.enumerateProcesses(siteName, instance.name, publishCredential);

--- a/src/diagnostics/wizardSteps/SessionAttachStep.ts
+++ b/src/diagnostics/wizardSteps/SessionAttachStep.ts
@@ -21,7 +21,7 @@ export class SessionAttachStep extends WizardStep {
         let result: CommandRunResult<IAttachProcessResponse>;
         const requestData: IAttachProcessRequest = { sessionId: this._wizard.sessionId, processId: this._wizard.processId };
 
-        const siteName = util.extractSiteName(selectedSlot) + (util.isSiteDeploymentSlot(selectedSlot) ? `-${util.extractDeploymentSlotName(selectedSlot)}` : '');
+        const siteName = util.extractSiteScmSubDomainName(selectedSlot);
 
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async p => {
             const message = `Attach debugging to session ${this._wizard.sessionId}...`;
@@ -38,8 +38,7 @@ export class SessionAttachStep extends WizardStep {
             this._wizard.debuggerId = result.json.data.debugeeId;
             this._wizard.writeline(`Attached to process ${this._wizard.processId}, got debugId ${this._wizard.debuggerId}`);
         } else {
-            this._wizard.writeline(`Attached to process ${this._wizard.processId} failed, got response ${result.output}`);
-            throw new Error('Attaching process failed.');
+            throw new Error(`Attached to process ${this._wizard.processId} failed, got response ${result.json.error.message}`);
         }
     }
 }

--- a/src/diagnostics/wizardSteps/StartDebugAdapterStep.ts
+++ b/src/diagnostics/wizardSteps/StartDebugAdapterStep.ts
@@ -10,7 +10,8 @@ export class StartDebugAdapterStep extends WizardStep {
 
     public async execute(): Promise<void> {
         const site = this._wizard.selectedDeploymentSlot;
-        const siteName = util.extractSiteName(site) + (util.isSiteDeploymentSlot(site) ? `-${util.extractDeploymentSlotName(site)}` : '');
+        const siteName = util.extractSiteScmSubDomainName(site);
+
         const publishCredential = await this._wizard.getCachedCredentialOrRefetch(site);
 
         // Assume the next started debug sessionw is the one we will launch next.
@@ -21,7 +22,7 @@ export class StartDebugAdapterStep extends WizardStep {
         });
         await vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], {
             type: "jsLogpoints",
-            name: "Azure App Service LogPoints",
+            name: siteName,
             request: "attach",
             trace: true,
             siteName: siteName,

--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -79,7 +79,7 @@ export abstract class SiteTreeItem implements IAzureParentTreeItem {
         await this.siteWrapper.enableHttpLogs(client);
     }
 
-    public async connectToLogStream(client: WebSiteManagementClient, extensionContext: ExtensionContext): Promise<void> {
+    public async connectToLogStream(client: WebSiteManagementClient, extensionContext: ExtensionContext): Promise<OutputChannel> {
         const siteName = this.siteWrapper.appName;
         const user = await util.getWebAppPublishCredential(client, this.site);
         const kuduClient = new KuduClient(siteName, user.publishingUserName, user.publishingPassword);
@@ -102,6 +102,8 @@ export abstract class SiteTreeItem implements IAzureParentTreeItem {
         }).on('complete', () => {
             this._logStreamOutputChannel.appendLine('Disconnected from log-streaming service.');
         });
+
+        return this._logStreamOutputChannel;
     }
 
     public stopLogStream(): void {
@@ -121,7 +123,7 @@ export abstract class SiteTreeItem implements IAzureParentTreeItem {
     }
 
     private createLabel(state: string): string {
-        return `${this.siteWrapper.slotName ? this.siteWrapper.slotName : this.siteWrapper.name} ${state && state.toLowerCase() !== 'running' ? '(' + state + ')' : ''}`;
+        return `${this.siteWrapper.slotName ? this.siteWrapper.slotName : this.siteWrapper.name} ${state && state.toLowerCase() !== 'running' ? `(${state})` : ''}`;
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -272,7 +272,7 @@ export function activate(context: vscode.ExtensionContext): void {
     initAsyncCommand(context, 'diagnostics.StartLogPointsSession', async (node: IAzureNode<SiteTreeItem>) => {
         if (node) {
             const client: WebSiteManagementClient = nodeUtils.getWebSiteClient(node);
-            const wizard = new LogPointsSessionWizard(outputChannel, node, client);
+            const wizard = new LogPointsSessionWizard(logPointsManager, context, outputChannel, node, client);
             await wizard.run();
         }
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,6 +18,10 @@ export function extractSiteName(site: WebSiteModels.Site): string {
     return isSiteDeploymentSlot(site) ? site.name.substring(0, site.name.lastIndexOf('/')) : site.name;
 }
 
+export function extractSiteScmSubDomainName(site: WebSiteModels.Site): string {
+    return extractSiteName(site) + (isSiteDeploymentSlot(site) ? `-${extractDeploymentSlotName(site)}` : '');
+}
+
 export function extractDeploymentSlotName(site: WebSiteModels.Site): string | undefined {
     return isSiteDeploymentSlot(site) ? site.name.substring(site.name.lastIndexOf('/') + 1) : undefined;
 }
@@ -37,7 +41,7 @@ export function getOutputChannel(): vscode.OutputChannel {
 }
 
 // Telemetry for the extension
-export function sendTelemetry(eventName: string, properties?: { [key: string]: string; }, measures?: { [key: string]: number; }) {
+export function sendTelemetry(eventName: string, properties?: { [key: string]: string; }, measures?: { [key: string]: number; }): void {
     if (reporter) {
         reporter.sendTelemetryEvent(eventName, properties, measures);
     }


### PR DESCRIPTION
and switch to the streaming log pane after debug session is launched.

Also fixes a bug that picking a deployment slot did not work correctly with opening a streaming log logic.

Also fixes a bug that error message from attaching a process was not displayed correctly.

Also Refactors the code that extracting the scm sub-domain name. 
