### PR TITLE
When start a new session, send the account identity as well.

### DIFF
--- a/package.json
+++ b/package.json
@@ -586,7 +586,7 @@
         "request": "^2.83.0",
         "simple-git": "^1.77.0",
         "vscode-azureappservice": "~0.8.0",
-        "vscode-azureextensionui": "~0.3.0",
+        "vscode-azureextensionui": "~0.4.1",
         "vscode-debugadapter": "^1.24.0",
         "vscode-debugprotocol": "^1.24.0",
         "vscode-extension-telemetry": "^0.0.8"

--- a/src/diagnostics/LogPointsManager.ts
+++ b/src/diagnostics/LogPointsManager.ts
@@ -53,7 +53,7 @@ class DebugSessionManager {
         const uriString = documentUri.toString();
         let logpointsCollection = this._logpointsCollectionMapping[uriString];
 
-        // If we have not seen any logpoints fro this collection,
+        // If we have not seen any logpoints for this collection,
         // try to contact server and see if it knows about any existing logpoints.
         if (!logpointsCollection) {
             logpointsCollection = new LogpointsCollection(documentUri);

--- a/src/diagnostics/structs/IStartSessionRequest.ts
+++ b/src/diagnostics/structs/IStartSessionRequest.ts
@@ -1,0 +1,3 @@
+export interface IStartSessionRequest {
+    username: string;
+}

--- a/src/diagnostics/wizardSteps/GetUnoccupiedInstance.ts
+++ b/src/diagnostics/wizardSteps/GetUnoccupiedInstance.ts
@@ -7,6 +7,7 @@ import { WizardStep } from '../../wizard';
 import { ILogPointsDebuggerClient } from '../logPointsClient';
 import { LogPointsSessionWizard } from '../LogPointsSessionWizard';
 import { CommandRunResult } from '../structs/CommandRunResult';
+import { IStartSessionRequest } from '../structs/IStartSessionRequest';
 import { IStartSessionResponse } from '../structs/IStartSessionResponse';
 
 export class GetUnoccupiedInstance extends WizardStep {
@@ -36,6 +37,7 @@ export class GetUnoccupiedInstance extends WizardStep {
         });
 
         const siteName = util.extractSiteScmSubDomainName(selectedSlot);
+        const startSessionRequest: IStartSessionRequest = { username: this._wizard.uiTreeItem.userId };
 
         for (const instance of instances) {
             let result: CommandRunResult<IStartSessionResponse>;
@@ -48,7 +50,7 @@ export class GetUnoccupiedInstance extends WizardStep {
                 try {
                     result = await callWithTimeout(
                         () => {
-                            return this._logPointsDebuggerClient.startSession(siteName, instance.name, publishCredential);
+                            return this._logPointsDebuggerClient.startSession(siteName, instance.name, publishCredential, startSessionRequest);
                         },
                         DEFAULT_TIMEOUT);
                 } catch (e) {


### PR DESCRIPTION
This addresses issue #230 