### PR TITLE
Remove extra space in site label

### DIFF
--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -128,7 +128,8 @@ export abstract class SiteTreeItem implements IAzureParentTreeItem {
     }
 
     private createLabel(state: string): string {
-        return `${this.siteWrapper.slotName ? this.siteWrapper.slotName : this.siteWrapper.name}${state && state.toLowerCase() !== 'running' ? ` (${state})` : ''}`;
+        return (this.siteWrapper.slotName ? this.siteWrapper.slotName : this.siteWrapper.name) +    // Site/slot name
+            (state && state.toLowerCase() !== 'running' ? ` (${state})` : '');  // Status (if site/slot not running)
     }
 }
 

--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -128,7 +128,7 @@ export abstract class SiteTreeItem implements IAzureParentTreeItem {
     }
 
     private createLabel(state: string): string {
-        return `${this.siteWrapper.slotName ? this.siteWrapper.slotName : this.siteWrapper.name} ${state && state.toLowerCase() !== 'running' ? `(${state})` : ''}`;
+        return `${this.siteWrapper.slotName ? this.siteWrapper.slotName : this.siteWrapper.name}${state && state.toLowerCase() !== 'running' ? ` (${state})` : ''}`;
     }
 }
 


### PR DESCRIPTION
Related to #264 

The label contained an extra space when the site status is "Running".