### PR TITLE
Implement File node to Deployment Slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -602,6 +602,7 @@
         "simple-git": "^1.77.0",
         "vscode-azureappservice": "~0.8.0",
         "vscode-azureextensionui": "~0.5.0",
+        "vscode-azurekudu": "^0.1.4",
         "vscode-debugadapter": "^1.24.0",
         "vscode-debugprotocol": "^1.24.0",
         "vscode-extension-telemetry": "^0.0.10"

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -14,8 +14,8 @@ import { SiteTreeItem } from './SiteTreeItem';
 export class DeploymentSlotTreeItem extends SiteTreeItem {
     public static contextValue: string = 'deploymentSlot';
     public readonly contextValue: string = DeploymentSlotTreeItem.contextValue;
-    public readonly appSettingsNode: IAzureTreeItem;
-    public readonly folderNode: IAzureTreeItem;
+    private readonly appSettingsNode: IAzureTreeItem;
+    private readonly folderNode: IAzureTreeItem;
 
     constructor(site: WebSiteModels.Site) {
         super(site);

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -19,7 +19,7 @@ export class DeploymentSlotTreeItem extends SiteTreeItem {
 
     constructor(site: WebSiteModels.Site) {
         super(site);
-        this.folderNode = new FolderTreeItem(site, 'Files', "/site/wwwroot", true);
+        this.folderNode = new FolderTreeItem(this.siteWrapper, 'Files', "/site/wwwroot", true);
         this.appSettingsNode = new AppSettingsTreeItem(this.siteWrapper);
     }
 

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -5,16 +5,22 @@
 
 import * as WebSiteModels from 'azure-arm-website/lib/models';
 import * as path from 'path';
+import { workspace } from 'vscode';
 import { AppSettingsTreeItem } from 'vscode-azureappservice';
 import { IAzureParentNode, IAzureTreeItem } from 'vscode-azureextensionui';
+import { FolderTreeItem } from './FolderTreeItem';
 import { SiteTreeItem } from './SiteTreeItem';
 
 export class DeploymentSlotTreeItem extends SiteTreeItem {
     public static contextValue: string = 'deploymentSlot';
     public readonly contextValue: string = DeploymentSlotTreeItem.contextValue;
+    public readonly appSettingsNode: IAzureTreeItem;
+    public readonly folderNode: IAzureTreeItem;
 
     constructor(site: WebSiteModels.Site) {
         super(site);
+        this.folderNode = new FolderTreeItem(site, 'Files', "/site/wwwroot", true);
+        this.appSettingsNode = new AppSettingsTreeItem(this.siteWrapper);
     }
 
     public get iconPath(): { light: string, dark: string } {
@@ -24,7 +30,20 @@ export class DeploymentSlotTreeItem extends SiteTreeItem {
         };
     }
 
-    public async loadMoreChildren(node: IAzureParentNode<DeploymentSlotTreeItem>): Promise<IAzureTreeItem[]> {
-        return [new AppSettingsTreeItem(node.treeItem.siteWrapper)];
+    public async loadMoreChildren(_node: IAzureParentNode<DeploymentSlotTreeItem>): Promise<IAzureTreeItem[]> {
+        return workspace.getConfiguration().get("appService.showRemoteFiles") ?
+            [this.folderNode, this.appSettingsNode] :
+            [this.appSettingsNode];
+    }
+
+    public pickTreeItem(expectedContextValue: string): IAzureTreeItem | undefined {
+        switch (expectedContextValue) {
+            case AppSettingsTreeItem.contextValue:
+                return this.appSettingsNode;
+            case FolderTreeItem.contextValue:
+                return this.folderNode;
+            default:
+                return undefined;
+        }
     }
 }

--- a/src/explorer/FileTreeItem.ts
+++ b/src/explorer/FileTreeItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Site } from 'azure-arm-website/lib/models';
+import { SiteWrapper } from 'vscode-azureappservice';
 import { IAzureTreeItem } from 'vscode-azureextensionui';
 
 export class FileTreeItem implements IAzureTreeItem {
@@ -11,10 +11,10 @@ export class FileTreeItem implements IAzureTreeItem {
     public readonly contextValue: string = FileTreeItem.contextValue;
     public readonly commandId: string = 'appService.showFile';
 
-    constructor(readonly site: Site, readonly label: string, readonly path: string) {
+    constructor(readonly siteWrapper: SiteWrapper, readonly label: string, readonly path: string) {
     }
 
     public get id(): string {
-        return `${this.site.id}/File`;
+        return `${this.siteWrapper.id}/File`;
     }
 }

--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -15,7 +15,7 @@ import { nodeUtils } from '../utils/nodeUtils';
 export class FolderTreeItem implements IAzureParentTreeItem {
     public static contextValue: string = 'folder';
     public readonly contextValue: string = FolderTreeItem.contextValue;
-    public readonly childTypeLabel: string = 'Files';
+    public readonly childTypeLabel: string = 'files';
     constructor(readonly siteWrapper: SiteWrapper, readonly label: string, readonly path: string, readonly useIcon: boolean = false) {
     }
 

--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -3,23 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Site } from 'azure-arm-website/lib/models';
 import * as path from 'path';
 import { IAzureNode, IAzureParentTreeItem, IAzureTreeItem } from 'vscode-azureextensionui';
+import { SiteWrapper } from 'vscode-azureappservice';
+import WebSiteManagementClient = require('azure-arm-website');
+import KuduClient from 'vscode-azurekudu';
+import { kuduFile } from '../KuduClient';
 import { FileTreeItem } from './FileTreeItem';
-import { KuduClient, kuduFile } from '../KuduClient';
-import * as util from '../util';
 import { nodeUtils } from '../utils/nodeUtils';
 
 export class FolderTreeItem implements IAzureParentTreeItem {
     public static contextValue: string = 'folder';
     public readonly contextValue: string = FolderTreeItem.contextValue;
-    public readonly childTypeLabel: string = 'files';
-    constructor(readonly site: Site, readonly label: string, readonly path: string, readonly useIcon: boolean = false) {
+    public readonly childTypeLabel: string = 'Files';
+    constructor(readonly siteWrapper: SiteWrapper, readonly label: string, readonly path: string, readonly useIcon: boolean = false) {
     }
 
     public get id(): string {
-        return `${this.site.id}/Folders`;
+        return `${this.siteWrapper.id}/Folders`;
     }
 
     public get iconPath(): { light: string, dark: string } | undefined {
@@ -34,17 +35,15 @@ export class FolderTreeItem implements IAzureParentTreeItem {
     }
 
     public async loadMoreChildren(node: IAzureNode<FolderTreeItem>): Promise<IAzureTreeItem[]> {
-        const webAppClient = nodeUtils.getWebSiteClient(node);
-        const user = await util.getWebAppPublishCredential(webAppClient, node.treeItem.site);
-        const kuduClient = new KuduClient(node.treeItem.site.name, user.publishingUserName, user.publishingPassword);
+        const webAppClient: WebSiteManagementClient = nodeUtils.getWebSiteClient(node);
+        const kuduClient: KuduClient = await this.siteWrapper.getKuduClient(webAppClient);
 
-        const fileList: kuduFile[] = await kuduClient.listFiles(this.path);
-
+        const fileList = await kuduClient.vfs.getItem(this.path);
         return fileList.map((file: kuduFile) => {
             return file.mime === 'inode/directory' ?
                 // truncate the /home of the path
-                new FolderTreeItem(this.site, file.name, file.path.substring(file.path.indexOf('site'))) :
-                new FileTreeItem(this.site, file.name, file.path.substring(file.path.indexOf('site')));
+                new FolderTreeItem(this.siteWrapper, file.name, file.path.substring(file.path.indexOf('site'))) :
+                new FileTreeItem(this.siteWrapper, file.name, file.path.substring(file.path.indexOf('site')));
         });
     }
 }

--- a/src/explorer/WebAppTreeItem.ts
+++ b/src/explorer/WebAppTreeItem.ts
@@ -30,7 +30,7 @@ export class WebAppTreeItem extends SiteTreeItem {
     constructor(site: Site, appServicePlan: AppServicePlan) {
         super(site);
         this.deploymentSlotsNode = appServicePlan.sku.tier === 'Basic' ? new DeploymentSlotsNATreeItem() : new DeploymentSlotsTreeItem(site);
-        this.folderNode = new FolderTreeItem(site, 'Files', "/site/wwwroot", true);
+        this.folderNode = new FolderTreeItem(this.siteWrapper, 'Files', "/site/wwwroot", true);
         // https://github.com/Microsoft/vscode-azureappservice/issues/45
         // nodes.push(new FilesNode('Log Files', '/LogFiles', this.site, this.subscription));
         this.webJobsNode = new WebJobsTreeItem(site);

--- a/src/explorer/editors/FileEditor.ts
+++ b/src/explorer/editors/FileEditor.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as util from '../../util';
 import { BaseEditor, IAzureNode } from 'vscode-azureextensionui';
 import { FileTreeItem } from '../FileTreeItem';
 import { KuduClient } from '../../KuduClient';
@@ -17,7 +16,7 @@ export class FileEditor extends BaseEditor<IAzureNode<FileTreeItem>> {
     }
 
     async getSaveConfirmationText(node: IAzureNode<FileTreeItem>): Promise<string> {
-        return `Saving '${node.treeItem.label}' will update the file "${node.treeItem.label}" in "${node.treeItem.site.name}".`;
+        return `Saving '${node.treeItem.label}' will update the file "${node.treeItem.label}" in "${node.treeItem.siteWrapper.name}".`;
     }
 
     async getFilename(node: IAzureNode<FileTreeItem>): Promise<string> {
@@ -26,8 +25,9 @@ export class FileEditor extends BaseEditor<IAzureNode<FileTreeItem>> {
 
     async getData(node: IAzureNode<FileTreeItem>): Promise<string> {
         const webAppClient = nodeUtils.getWebSiteClient(node);
-        const user = await util.getWebAppPublishCredential(webAppClient, node.treeItem.site);
-        const kuduClient = new KuduClient(node.treeItem.site.name, user.publishingUserName, user.publishingPassword);
+        const publishingCredential = await node.treeItem.siteWrapper.getWebAppPublishCredential(webAppClient);
+        const kuduClient = new KuduClient(node.treeItem.siteWrapper.name, publishingCredential.publishingUserName, publishingCredential.publishingPassword);
+
         return await kuduClient.getFile(node.treeItem.path);
     }
 
@@ -39,8 +39,8 @@ export class FileEditor extends BaseEditor<IAzureNode<FileTreeItem>> {
 
     async updateData(node: IAzureNode<FileTreeItem>): Promise<string> {
         const webAppClient = nodeUtils.getWebSiteClient(node);
-        const user = await util.getWebAppPublishCredential(webAppClient, node.treeItem.site);
-        const kuduClient = new KuduClient(node.treeItem.site.name, user.publishingUserName, user.publishingPassword);
+        const publishingCredential = await node.treeItem.siteWrapper.getWebAppPublishCredential(webAppClient);
+        const kuduClient = new KuduClient(node.treeItem.siteWrapper.name, publishingCredential.publishingUserName, publishingCredential.publishingPassword);
 
         const localPath: string = vscode.window.activeTextEditor.document.fileName;
         const destPath: string = node.treeItem.path;

--- a/src/explorer/editors/FileEditor.ts
+++ b/src/explorer/editors/FileEditor.ts
@@ -16,7 +16,7 @@ export class FileEditor extends BaseEditor<IAzureNode<FileTreeItem>> {
     }
 
     async getSaveConfirmationText(node: IAzureNode<FileTreeItem>): Promise<string> {
-        return `Saving '${node.treeItem.label}' will update the file "${node.treeItem.label}" in "${node.treeItem.siteWrapper.name}".`;
+        return `Saving '${node.treeItem.label}' will update the file "${node.treeItem.label}" in "${node.treeItem.siteWrapper.appName}".`;
     }
 
     async getFilename(node: IAzureNode<FileTreeItem>): Promise<string> {
@@ -40,7 +40,7 @@ export class FileEditor extends BaseEditor<IAzureNode<FileTreeItem>> {
     async updateData(node: IAzureNode<FileTreeItem>): Promise<string> {
         const webAppClient = nodeUtils.getWebSiteClient(node);
         const publishingCredential = await node.treeItem.siteWrapper.getWebAppPublishCredential(webAppClient);
-        const kuduClient = new KuduClient(node.treeItem.siteWrapper.name, publishingCredential.publishingUserName, publishingCredential.publishingPassword);
+        const kuduClient = new KuduClient(node.treeItem.siteWrapper.appName, publishingCredential.publishingUserName, publishingCredential.publishingPassword);
 
         const localPath: string = vscode.window.activeTextEditor.document.fileName;
         const destPath: string = node.treeItem.path;

--- a/src/explorer/editors/FileEditor.ts
+++ b/src/explorer/editors/FileEditor.ts
@@ -26,7 +26,7 @@ export class FileEditor extends BaseEditor<IAzureNode<FileTreeItem>> {
     async getData(node: IAzureNode<FileTreeItem>): Promise<string> {
         const webAppClient = nodeUtils.getWebSiteClient(node);
         const publishingCredential = await node.treeItem.siteWrapper.getWebAppPublishCredential(webAppClient);
-        const kuduClient = new KuduClient(node.treeItem.siteWrapper.name, publishingCredential.publishingUserName, publishingCredential.publishingPassword);
+        const kuduClient = new KuduClient(node.treeItem.siteWrapper.appName, publishingCredential.publishingUserName, publishingCredential.publishingPassword);
 
         return await kuduClient.getFile(node.treeItem.path);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,7 +215,7 @@ export function activate(context: vscode.ExtensionContext): void {
         }
 
         const wizard = new DeploymentSlotSwapper(outputChannel, node);
-        const result = await wizard.run(properties);
+        await wizard.run(properties);
 
     });
     actionHandler.registerCommand('appSettings.Add', async (node: IAzureParentNode<AppSettingsTreeItem>) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,13 +209,14 @@ export function activate(context: vscode.ExtensionContext): void {
             await createdSlot.treeItem.siteWrapper.deploy(fsPath, client, outputChannel, 'appService', false);
         }
     });
-    actionHandler.registerCommandWithCustomTelemetry('deploymentSlot.SwapSlots', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, node: IAzureNode<DeploymentSlotTreeItem>) => {
+    actionHandler.registerCommandWithCustomTelemetry('deploymentSlot.SwapSlots', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, node: IAzureParentNode<DeploymentSlotTreeItem>) => {
         if (!node) {
             node = <IAzureParentNode<DeploymentSlotTreeItem>>await tree.showNodePicker(DeploymentSlotTreeItem.contextValue);
         }
 
         const wizard = new DeploymentSlotSwapper(outputChannel, node);
-        await wizard.run(properties);
+        const result = await wizard.run(properties);
+
     });
     actionHandler.registerCommand('appSettings.Add', async (node: IAzureParentNode<AppSettingsTreeItem>) => {
         if (!node) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,14 +209,13 @@ export function activate(context: vscode.ExtensionContext): void {
             await createdSlot.treeItem.siteWrapper.deploy(fsPath, client, outputChannel, 'appService', false);
         }
     });
-    actionHandler.registerCommandWithCustomTelemetry('deploymentSlot.SwapSlots', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, node: IAzureParentNode<DeploymentSlotTreeItem>) => {
+    actionHandler.registerCommandWithCustomTelemetry('deploymentSlot.SwapSlots', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, node: IAzureNode<DeploymentSlotTreeItem>) => {
         if (!node) {
-            node = <IAzureParentNode<DeploymentSlotTreeItem>>await tree.showNodePicker(DeploymentSlotTreeItem.contextValue);
+            node = <IAzureNode<DeploymentSlotTreeItem>>await tree.showNodePicker(DeploymentSlotTreeItem.contextValue);
         }
 
         const wizard = new DeploymentSlotSwapper(outputChannel, node);
         await wizard.run(properties);
-
     });
     actionHandler.registerCommand('appSettings.Add', async (node: IAzureParentNode<AppSettingsTreeItem>) => {
         if (!node) {


### PR DESCRIPTION
Fixes #250 

* Leverage azurekudu package (still need to leverage for getting/putting files in FileEditor)
* Refactor deploymentSwapper to hold node as data rather than site to allow refreshing node after a swap
* Add File node to Slots