### PR TITLE
Remove "tools" from the name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "displayName": "Azure App Service Tools",
+    "displayName": "Azure App Service",
     "description": "An Azure App Service management extension for Visual Studio Code.",
     "version": "0.5.0",
     "publisher": "ms-azuretools",


### PR DESCRIPTION
"Tools" is synonymous with "extension" and ends up creating some redundancy in
the docs: "Azure App Service Tools extension," so I removed it. This also
creates consistency between the other extensions.