### PR TITLE
Fixing some minor bugs in logpoints

### DIFF
--- a/src/diagnostics/wizardSteps/EligibilityCheck.ts
+++ b/src/diagnostics/wizardSteps/EligibilityCheck.ts
@@ -13,7 +13,7 @@ export class EligibilityCheck extends WizardStep {
 
         const kind = site.kind;
 
-        if (!/linux$/.test(kind)) {
+        if (!/(^|,)linux($|,)/.test(kind)) {
             throw new Error('Only Linux App Services are suppored');
         }
 

--- a/src/diagnostics/wizardSteps/StartDebugAdapterStep.ts
+++ b/src/diagnostics/wizardSteps/StartDebugAdapterStep.ts
@@ -20,7 +20,8 @@ export class StartDebugAdapterStep extends WizardStep {
 
             vscode.commands.executeCommand('workbench.view.debug');
         });
-        await vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], {
+        const folder = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined;
+        await vscode.debug.startDebugging(folder, {
             type: "jsLogpoints",
             name: siteName,
             request: "attach",

--- a/src/diagnostics/wizardSteps/StartDebugAdapterStep.ts
+++ b/src/diagnostics/wizardSteps/StartDebugAdapterStep.ts
@@ -20,7 +20,7 @@ export class StartDebugAdapterStep extends WizardStep {
 
             vscode.commands.executeCommand('workbench.view.debug');
         });
-        const folder = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined;
+        const folder = undefined; // For logpoints scenarios, workspace folder is always undefined
         await vscode.debug.startDebugging(folder, {
             type: "jsLogpoints",
             name: siteName,


### PR DESCRIPTION
Two bug fixes:
1.  In some cases, `site.kind` can have a value like `app,linux,container`.  Updated the regular expression to be more tolerant of this pattern.
2.  In some cases,  `vscode.workspace.workspaceFolders` can be undefined.  Check for undefined now before indexing into array.  `startDebugging(...)` API is tolerant of undefined values for the folder.