### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -598,7 +598,7 @@
         "opn": "^5.1.0",
         "request": "^2.83.0",
         "vscode-azureappservice": "~0.8.0",
-        "vscode-azureextensionui": "^0.5.4",
+        "vscode-azureextensionui": "~0.5.4",
         "vscode-azurekudu": "^0.1.5",
         "vscode-debugadapter": "^1.24.0",
         "vscode-debugprotocol": "^1.24.0",


### PR DESCRIPTION
^ matches to only the major version where as ~ matches both the major and the minor.  The reason we need to change this to ~ is because as are a preview extension, a change to 0.6.0 may be breaking and we want to be able to control when the packages get updated within our extension.