### PR TITLE
Remove ids from files and folders nodes

### DIFF
--- a/src/explorer/FileTreeItem.ts
+++ b/src/explorer/FileTreeItem.ts
@@ -15,7 +15,4 @@ export class FileTreeItem implements IAzureTreeItem {
     constructor(readonly siteWrapper: SiteWrapper, readonly label: string, readonly path: string) {
     }
 
-    public get id(): string {
-        return `${this.siteWrapper.id}/File`;
-    }
 }

--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -20,10 +20,6 @@ export class FolderTreeItem implements IAzureParentTreeItem {
     constructor(readonly siteWrapper: SiteWrapper, readonly label: string, readonly folderPath: string, readonly useIcon: boolean = false) {
     }
 
-    public get id(): string {
-        return `${this.siteWrapper.id}/Folders`;
-    }
-
     public get iconPath(): { light: string, dark: string } | undefined {
         return this.useIcon ? {
             light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Folder.png'),


### PR DESCRIPTION
This was causing an issue and there is no reason for these nodes to have ids as they do not change state or are opened in the portal.

This will break until azuretools is updated to where id properties are optional.

Fixes #303 