### PR TITLE
Fix for deployment slot open in portal

### DIFF
--- a/src/explorer/DeploymentSlotsTreeItem.ts
+++ b/src/explorer/DeploymentSlotsTreeItem.ts
@@ -98,7 +98,7 @@ export class DeploymentSlotsTreeItem implements IAzureParentTreeItem {
                     return `The slot name "${value}" is not available.`;
                 }
 
-                const nameAvailability: ResourceNameAvailability = await nodeUtils.getWebSiteClient(node).checkNameAvailability(`$${util.extractSiteName(node.treeItem.site)}-{value}`, 'Slot');
+                const nameAvailability: ResourceNameAvailability = await nodeUtils.getWebSiteClient(node).checkNameAvailability(`${util.extractSiteName(node.treeItem.site)}-${value}`, 'Slot');
                 if (!nameAvailability.nameAvailable) {
                     return nameAvailability.message;
                 }

--- a/src/explorer/DeploymentSlotsTreeItem.ts
+++ b/src/explorer/DeploymentSlotsTreeItem.ts
@@ -98,7 +98,7 @@ export class DeploymentSlotsTreeItem implements IAzureParentTreeItem {
                     return `The slot name "${value}" is not available.`;
                 }
 
-                const nameAvailability: ResourceNameAvailability = await nodeUtils.getWebSiteClient(node).checkNameAvailability(`${util.extractSiteName(node.treeItem.site)}-${value}`, 'Slot');
+                const nameAvailability: ResourceNameAvailability = await nodeUtils.getWebSiteClient(node).checkNameAvailability(`${value}`, 'Slot');
                 if (!nameAvailability.nameAvailable) {
                     return nameAvailability.message;
                 }

--- a/src/explorer/DeploymentSlotsTreeItem.ts
+++ b/src/explorer/DeploymentSlotsTreeItem.ts
@@ -98,7 +98,7 @@ export class DeploymentSlotsTreeItem implements IAzureParentTreeItem {
                     return `The slot name "${value}" is not available.`;
                 }
 
-                const nameAvailability: ResourceNameAvailability = await nodeUtils.getWebSiteClient(node).checkNameAvailability(`${value}`, 'Slot');
+                const nameAvailability: ResourceNameAvailability = await nodeUtils.getWebSiteClient(node).checkNameAvailability(`$${util.extractSiteName(node.treeItem.site)}-{value}`, 'Slot');
                 if (!nameAvailability.nameAvailable) {
                     return nameAvailability.message;
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: vscode.ExtensionContext): void {
             node = <IAzureNode<WebAppTreeItem>>await tree.showNodePicker(WebAppTreeItem.contextValue);
         }
 
-        node.treeItem.contextValue === 'deploymentSlot' ? node.openInPortal(`${node.treeItem.id}`) : node.openInPortal();
+        node.treeItem.contextValue === 'deploymentSlot' ? node.openInPortal(node.treeItem.id) : node.openInPortal();
     });
     actionHandler.registerCommand('appService.Start', async (node: IAzureNode<SiteTreeItem>) => {
         if (!node) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: vscode.ExtensionContext): void {
             node = <IAzureNode<WebAppTreeItem>>await tree.showNodePicker(WebAppTreeItem.contextValue);
         }
 
-        node.treeItem.contextValue === 'deploymentSlot' ? node.openInPortal(`${node.parent.parent.treeItem.id}/slots/${node.treeItem.label}`) : node.openInPortal();
+        node.treeItem.contextValue === 'deploymentSlot' ? node.openInPortal(`${node.treeItem.id}`) : node.openInPortal();
     });
     actionHandler.registerCommand('appService.Start', async (node: IAzureNode<SiteTreeItem>) => {
         if (!node) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,7 @@ export function activate(context: vscode.ExtensionContext): void {
         }
 
         node.treeItem.contextValue === 'deploymentSlot' ? node.openInPortal(node.treeItem.id) : node.openInPortal();
+        // the deep link for slots does not follow the conventional pattern of including its parent in the path name so this is how we extract the slot's id
     });
     actionHandler.registerCommand('appService.Start', async (node: IAzureNode<SiteTreeItem>) => {
         if (!node) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: vscode.ExtensionContext): void {
             node = <IAzureNode<WebAppTreeItem>>await tree.showNodePicker(WebAppTreeItem.contextValue);
         }
 
-        node.openInPortal();
+        node.treeItem.contextValue === 'deploymentSlot' ? node.openInPortal(`${node.parent.parent.treeItem.id}/slots/${node.treeItem.label}`) : node.openInPortal();
     });
     actionHandler.registerCommand('appService.Start', async (node: IAzureNode<SiteTreeItem>) => {
         if (!node) {

--- a/tslint.json
+++ b/tslint.json
@@ -170,7 +170,7 @@
         "no-var-requires": true,
         "no-var-self": true,
         "no-void-expression": [
-            true,
+            false, // changed
             "ignore-arrow-function-shorthand" // changed
         ],
         "object-literal-sort-keys": false,


### PR DESCRIPTION
Fixes #311

Depends on this PR: https://github.com/Microsoft/vscode-azuretools/pull/94

<del>When creating slots, the name availability check included the app's name as well, basically padding the slot name with n characters.  This would prevent users from creating slots with 64 characters.</del>