### PR TITLE
Add min validation time and add elapsed seconds to telemetry

### DIFF
--- a/src/validateWebSite.ts
+++ b/src/validateWebSite.ts
@@ -65,7 +65,6 @@ export async function validateWebSite(siteTreeItem: SiteTreeItem, outputChannel:
                 break;
             }
 
-            // tslint:disable-next-line:no-string-based-set-timeout // false positive
             await delay(pollingIntervalMs);
             pollingIntervalMs += pollingIncrementMs;
         }
@@ -74,6 +73,7 @@ export async function validateWebSite(siteTreeItem: SiteTreeItem, outputChannel:
     });
 }
 
-function delay(delayMs: number): Promise<void> {
-    return new Promise<void>((resolve, _reject): void => { setTimeout(resolve, delayMs); });
+async function delay(delayMs: number): Promise<void> {
+    // tslint:disable-next-line:no-string-based-set-timeout // tslint false positive
+    await new Promise<void>((resolve, _reject): void => { setTimeout(resolve, delayMs); });
 }


### PR DESCRIPTION
Reworking of last PR - stop trying to report success/failure to the user, and just log simple telemetry for status codes after a deployment e.g.:

[{"code":200,"elapsed":4},{"code":200,"elapsed":9},{"code":200,"elapsed":14},{"code":200,"elapsed":19},{"code":200,"elapsed":24},{"code":200,"elapsed":29},{"code":200,"elapsed":34},{"code":200,"elapsed":40},{"code":200,"elapsed":45},{"code":200,"elapsed":50},{"code":200,"elapsed":55},{"code":200,"elapsed":60},{"code":200,"elapsed":65}] 

We can use this to help efforts to report success/failure in the future.