### PR TITLE
Add request-promise to thirdpartynotices

### DIFF
--- a/package.json
+++ b/package.json
@@ -603,6 +603,7 @@
         "kudu-api": "^1.4.1",
         "opn": "^5.1.0",
         "request": "^2.83.0",
+        "request-promise": "^4.2.2",
         "vscode-azureappservice": "~0.11.1",
         "vscode-azureextensionui": "~0.8.2",
         "vscode-azurekudu": "~0.1.6",

--- a/thirdpartynotices.txt
+++ b/thirdpartynotices.txt
@@ -9,6 +9,7 @@ all other rights not expressly granted, whether by implication, estoppel or othe
 2. kudu-api (https://github.com/itsananderson/kudu-api/)
 3. request (https://github.com/request/request)
 4. fs-extra (https://github.com/jprichardson/node-fs-extra)
+5. request-promise (https://github.com/request/request-promise)
 
 opn NOTICES BEGIN HERE
 =============================
@@ -246,4 +247,26 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 END OF fs-extra NOTICES AND INFORMATION
+==================================
+
+request-promise NOTICES BEGIN HERE
+=============================
+
+ISC License
+
+Copyright (c) 2017, Nicolai Kamenzky, Ty Abonil, and contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+END OF request-promise NOTICES AND INFORMATION
 ==================================


### PR DESCRIPTION
It wasn't included in 'package.json', but we're using it directly in validateWebSite. I guess it worked since it was a dependency of some other package, but we can't always rely on that.