### PR TITLE
Add deploy resource context menu to apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
             },
             {
                 "command": "appService.Deploy",
-                "title": "Deploy to Web App",
+                "title": "Deploy Resource",
                 "category": "Azure App Service",
                 "icon": {
                     "light": "resources/light/Deploy.svg",
@@ -311,7 +311,7 @@
                     "group": "2_appServiceControlCommands@4"
                 },
                 {
-                    "command": "appService.OpenVSTSCD",
+                    "command": "appService.Deploy",
                     "when": "view == azureAppService && viewItem == appService",
                     "group": "3_appServiceDeployCommands@1"
                 },
@@ -319,6 +319,11 @@
                     "command": "appService.ConfigureDeploymentSource",
                     "when": "view == azureAppService && viewItem == appService",
                     "group": "3_appServiceDeployCommands@2"
+                },
+                {
+                    "command": "appService.OpenVSTSCD",
+                    "when": "view == azureAppService && viewItem == appService",
+                    "group": "3_appServiceDeployCommands@3"
                 },
                 {
                     "command": "diagnostics.OpenLogStream",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
             },
             {
                 "command": "appService.Deploy",
-                "title": "Deploy Resource",
+                "title": "Deploy to Web App",
                 "category": "Azure App Service",
                 "icon": {
                     "light": "resources/light/Deploy.svg",


### PR DESCRIPTION
Fixes #284 

I opted to label the context action as "Deploy Resource" for the following reasons:

1. Staying consistent to Azure* that typically refers to projects you deploy to web apps as "resources".
2. Makes it more clear that the web app/slot is being ACTED on as the Resource/Project is the object of the sentence.  I think that this is more clear than "Deploy to Web App"

*https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-template-deploy-cli