### PR TITLE
Don't prompt destructive deploy action on newly created web apps

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,6 +161,12 @@ export function activate(context: vscode.ExtensionContext): void {
             node = target;
         }
 
+        let newApp: boolean = false;
+        // if the tree changes here, a new app was created
+        tree.onDidChangeTreeData(() => {
+            newApp = true;
+        });
+
         if (!node) {
             try {
                 node = <IAzureNode<WebAppTreeItem>>await tree.showNodePicker(WebAppTreeItem.contextValue);
@@ -173,7 +179,7 @@ export function activate(context: vscode.ExtensionContext): void {
         }
 
         try {
-            await node.treeItem.deploy(fsPath, outputChannel, ui, reporter, extensionPrefix, true, this.properties);
+            await node.treeItem.deploy(fsPath, outputChannel, ui, reporter, extensionPrefix, !newApp, this.properties);
         } catch (err) {
             if (parseError(err).isUserCancelledError) {
                 throw err;


### PR DESCRIPTION
There is a local listener that flips a boolean that is listening for a change on the tree.  If a web app is created, the boolean is flipped to true and the user is not prompted about destructive deploys.

Fixes #347