### PR TITLE
Fix open in portal for children of slots

### DIFF
--- a/src/explorer/DeploymentSlotsTreeItem.ts
+++ b/src/explorer/DeploymentSlotsTreeItem.ts
@@ -36,7 +36,7 @@ export class DeploymentSlotsTreeItem implements IAzureParentTreeItem {
     }
 
     public get id(): string {
-        return `${this.client.id}/deploymentSlots`;
+        return `${this.client.id}/slots`;
     }
 
     public hasMoreChildren(): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,7 @@ export function activate(context: vscode.ExtensionContext): void {
             node = <IAzureNode<WebAppTreeItem>>await tree.showNodePicker(WebAppTreeItem.contextValue);
         }
 
-        node.treeItem.contextValue === 'deploymentSlot' ? node.openInPortal(node.treeItem.id) : node.openInPortal();
+        node.treeItem.contextValue === DeploymentSlotsTreeItem.contextValue ? node.openInPortal(`${node.parent.id}/deploymentSlots`) : node.openInPortal();
         // the deep link for slots does not follow the conventional pattern of including its parent in the path name so this is how we extract the slot's id
     });
     actionHandler.registerCommand('appService.Start', async (node: IAzureNode<SiteTreeItem>) => {


### PR DESCRIPTION
Sample tree for the sake of discussion:
![screen shot 2018-03-26 at 8 35 08 am](https://user-images.githubusercontent.com/11282622/37916404-9db856a4-30d0-11e8-8b05-a70307c3af26.png)

There's an inconsistency with 'deploymentSlots' vs 'slots' in the portal and we have to special case _something_. However, rather than special-case the fourth node in the tree, I'm now special-casing the third node. This ensures that openInPortal works for any child of a slot, which fixes openInPortal for the fifth node in the tree. Fixes #362