### PR TITLE
Fix error on delete

### DIFF
--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -40,7 +40,11 @@ export abstract class SiteTreeItem implements IAzureParentTreeItem {
     }
 
     public async refreshLabel(): Promise<void> {
-        this._state = await this.client.getState();
+        try {
+            this._state = await this.client.getState();
+        } catch {
+            this._state = 'Unknown';
+        }
     }
 
     public hasMoreChildren(): boolean {


### PR DESCRIPTION
When I added support for runWithTemporaryDescription, it had the side-effect of re-getting the state after the site was already deleted. We could fail to get the state in other cases as well and I think its best to just show the state as 'Unknown' instead of displaying an error message

Fixes #380 