### PR TITLE
Move explorer to Azure viewContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Change Log
 All notable changes to the "azure-appservice" extension will be documented in this file.
 
-## 0.8.0 - 2018-05-01
+## 0.8.0 - 2018-05-03
 ### Added
 - Remote debugging support for Node.js on Linux (feature flag required)
 - Modal confirmation dialogs for more visibility
+
+### Changed
+- Moved App Service Explorer to Azure view container
 
 ### Fixed
 - [Bugs fixed](https://github.com/Microsoft/vscode-azureappservice/issues?utf8=%E2%9C%93&q=is%3Aissue+milestone%3A%220.8.0%22+label%3Abug+is%3Aclosed+)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/windows-azure-web-site.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.20.0"
+        "vscode": "^1.23.0"
     },
     "repository": {
         "type": "git",
@@ -208,8 +208,17 @@
                 "category": "Azure App Service"
             }
         ],
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "azure",
+                    "title": "Azure",
+                    "icon": "resources/azure.svg"
+                }
+            ]
+        },
         "views": {
-            "explorer": [
+            "azure": [
                 {
                     "id": "azureAppService",
                     "name": "Azure App Service",

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
             "azure": [
                 {
                     "id": "azureAppService",
-                    "name": "Azure App Service",
+                    "name": "App Service",
                     "when": "config.appService.showExplorer == true"
                 }
             ],

--- a/resources/azure.svg
+++ b/resources/azure.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg height="24" width="24" version="1.1" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+<svg height="30" width="30" version="1.1" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
   <g>
     <path fill="#0072C6" d="M11.423,44.326l23.623-4.156L22.894,25.748l6.328-17.346L50,44.33L11.423,44.326z M27.566,5.67L11.469,40.109v-0.034H0l12.717-21.975L27.566,5.67z" />
   </g>

--- a/resources/azure.svg
+++ b/resources/azure.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg height="30" width="30" version="1.1" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+<svg height="28" width="28" version="1.1" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
   <g>
     <path fill="#0072C6" d="M11.423,44.326l23.623-4.156L22.894,25.748l6.328-17.346L50,44.33L11.423,44.326z M27.566,5.67L11.469,40.109v-0.034H0l12.717-21.975L27.566,5.67z" />
   </g>

--- a/resources/azure.svg
+++ b/resources/azure.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg height="24" width="24" version="1.1" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <path fill="#0072C6" d="M11.423,44.326l23.623-4.156L22.894,25.748l6.328-17.346L50,44.33L11.423,44.326z M27.566,5.67L11.469,40.109v-0.034H0l12.717-21.975L27.566,5.67z" />
+  </g>
+</svg>


### PR DESCRIPTION
See https://github.com/Microsoft/vscode-azuretools/issues/167

Hopefully VS Code releases this update this week, but otherwise we can just ship the vsix that doesn't include this change

![screen shot 2018-05-01 at 4 15 03 pm](https://user-images.githubusercontent.com/11282622/39498048-dc527de4-4d5a-11e8-9b72-d292b015482a.png)

Edit: Updated screenshot after discussion with Matt
