### PR TITLE
Make subpathSetting more robust

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -47,11 +47,16 @@ export function parseAzureResourceId(resourceId: string): { [key: string]: strin
 export async function showWorkspaceFoldersQuickPick(placeHolderString: string, telemetryProperties: TelemetryProperties, subPathSetting: string | undefined): Promise<string> {
     const folderQuickPickItems = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders.map((value) => {
         {
-            const subpath: string = vscode.workspace.getConfiguration(extensionPrefix, value.uri).get(configurationSettings.deploySubpath);
-            const fsPath: string = subPathSetting ? path.join(value.uri.fsPath, subpath) : value.uri.fsPath;
+            let fsPath: string = value.uri.fsPath;
+            if (subPathSetting) {
+                const subpath: string = vscode.workspace.getConfiguration(extensionPrefix, value.uri).get(configurationSettings.deploySubpath);
+                if (subpath) {
+                    fsPath = path.join(fsPath, subpath);
+                }
+            }
 
             return {
-                label: value.name,
+                label: path.basename(fsPath),
                 description: fsPath,
                 data: fsPath
             };

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
-import { configurationSettings, extensionPrefix } from './constants';
+import { extensionPrefix } from './constants';
 
 // Output channel for the extension
 const outputChannel = vscode.window.createOutputChannel("Azure App Service");
@@ -49,7 +49,7 @@ export async function showWorkspaceFoldersQuickPick(placeHolderString: string, t
         {
             let fsPath: string = value.uri.fsPath;
             if (subPathSetting) {
-                const subpath: string = vscode.workspace.getConfiguration(extensionPrefix, value.uri).get(configurationSettings.deploySubpath);
+                const subpath: string = vscode.workspace.getConfiguration(extensionPrefix, value.uri).get(subPathSetting);
                 if (subpath) {
                     fsPath = path.join(fsPath, subpath);
                 }


### PR DESCRIPTION
From recent PR: https://github.com/Microsoft/vscode-azureappservice/pull/393. FYI @sunmorgus 
```
vscode.workspace.getConfiguration(extensionPrefix, value.uri).get(configurationSettings.deploySubpath);
```
^ The signature says it returns `string | undefined`, which would break `path.join`. In practice it seems to be returning an empty string for `subpath`, but I don't want to put my trust in that.

Also fixed the 'name' of the quick pick to be the proper directory name