### PR TITLE
ignoreFocusOut for showWorkspaceFolders

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -67,12 +67,11 @@ export async function showWorkspaceFoldersQuickPick(placeHolderString: string, t
     folderQuickPickItems.push({ label: '$(file-directory) Browse...', description: '', data: undefined });
 
     const folderQuickPickOption = { placeHolder: placeHolderString };
+    telemetryProperties.cancelStep = 'showWorkspaceFolders';
     const pickedItem = await ext.ui.showQuickPick(folderQuickPickItems, folderQuickPickOption);
+    telemetryProperties.cancelStep = '';
 
-    if (!pickedItem) {
-        telemetryProperties.cancelStep = 'showWorkspaceFolders';
-        throw new UserCancelledError();
-    } else if (!pickedItem.data) {
+    if (!pickedItem.data) {
         const browseResult = await vscode.window.showOpenDialog({
             canSelectFiles: false,
             canSelectFolders: true,

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { IAzureQuickPickItem, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
 import { extensionPrefix } from './constants';
+import { ext } from './extensionVariables';
 
 // Output channel for the extension
 const outputChannel = vscode.window.createOutputChannel("Azure App Service");
@@ -63,10 +64,10 @@ export async function showWorkspaceFoldersQuickPick(placeHolderString: string, t
         }
     }) : [];
 
-    folderQuickPickItems.unshift({ label: '$(file-directory) Browse...', description: '', data: undefined });
+    folderQuickPickItems.push({ label: '$(file-directory) Browse...', description: '', data: undefined });
 
     const folderQuickPickOption = { placeHolder: placeHolderString };
-    const pickedItem = await vscode.window.showQuickPick(folderQuickPickItems, folderQuickPickOption);
+    const pickedItem = await ext.ui.showQuickPick(folderQuickPickItems, folderQuickPickOption);
 
     if (!pickedItem) {
         telemetryProperties.cancelStep = 'showWorkspaceFolders';


### PR DESCRIPTION
Rather than `vscode.window.showQuickPick`, use `ext.ui`, which ignores focus out by default and leverages the '(recently used)' logic. This will hopefully help the cancel rate in #348 

Also make 'Browse...' the last pick since they likely will use the currently opened folder.