### PR TITLE
Add telemetry to measure time to establish remote debug tunnel proxy

### DIFF
--- a/src/commands/remoteDebug/startRemoteDebug.ts
+++ b/src/commands/remoteDebug/startRemoteDebug.ts
@@ -37,7 +37,11 @@ export async function startRemoteDebug(tree: AzureTreeDataProvider, node?: IAzur
 
         const publishCredential: User = await siteClient.getWebAppPublishCredential();
         const tunnelProxy: TunnelProxy = new TunnelProxy(portNumber, siteClient, publishCredential, ext.outputChannel);
-        await tunnelProxy.startProxy();
+        await callWithTelemetryAndErrorHandling('appService.remoteDebugStartProxy', ext.reporter, ext.outputChannel, async function (this: IActionContext): Promise<void> {
+            this.suppressErrorDisplay = true;
+            this.rethrowError = true;
+            await tunnelProxy.startProxy();
+        });
 
         remoteDebug.reportMessage('Attaching debugger...', progress);
 


### PR DESCRIPTION
Related to Microsoft/vscode-azureappservice#448

Add telemetry to measure specifically the time taken to establish the remote debug tunnel proxy