### PR TITLE
Remove not now button and only enable logging if app logging is enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -291,14 +291,14 @@ export function activate(context: vscode.ExtensionContext): void {
             await vscode.window.showWarningMessage(`The log-streaming service for "${node.treeItem.client.fullName}" is already active.`);
         } else {
             const enableButton: vscode.MessageItem = { title: 'Yes' };
-            const notNowButton: vscode.MessageItem = { title: 'Not Now', isCloseAffordance: true };
             const isEnabled = await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async p => {
                 p.report({ message: 'Checking container diagnostics settings...' });
                 // tslint:disable-next-line:no-non-null-assertion
                 return await node!.treeItem.isHttpLogsEnabled();
             });
 
-            if (!isEnabled && enableButton === await vscode.window.showWarningMessage(`Do you want to enable application logging for ${node.treeItem.client.fullName}?`, { modal: true }, enableButton, notNowButton)) {
+            if (!isEnabled) {
+                await ui.showWarningMessage(`Do you want to enable application logging for ${node.treeItem.client.fullName}? The web app will be restarted.`, { modal: true }, enableButton);
                 outputChannel.show();
                 outputChannel.appendLine(`Enabling Logging for "${node.treeItem.client.fullName}"...`);
                 await node.treeItem.enableHttpLogs();


### PR DESCRIPTION
Fixes #391 
Uses ui.showWarningMessage so that cancels will be handled appropriately.