### PR TITLE
Change home prefix based on app kind

### DIFF
--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -34,7 +34,7 @@ export class FolderTreeItem implements IAzureParentTreeItem {
         const httpResponse: kuduIncomingMessage = <kuduIncomingMessage>(await kuduClient.vfs.getItemWithHttpOperationResponse(this.folderPath)).response;
         // response contains a body with a JSON parseable string
         const fileList: kuduFile[] = <kuduFile[]>JSON.parse(httpResponse.body);
-        const home: string = 'home/';
+        const home: string = this.client.kind.includes('linux') ? 'home/' : 'home\\';
         return fileList.map((file: kuduFile) => {
             return file.mime === 'inode/directory' ?
                 // truncate the home/ of the path

--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -37,7 +37,9 @@ export class FolderTreeItem implements IAzureParentTreeItem {
         const home: string = 'home';
         return fileList.map((file: kuduFile) => {
             return file.mime === 'inode/directory' ?
-                // truncate the home/ of the path
+                // truncate the home of the path
+                // the substring starts at file.path.indexOf(home) because the path sometimes includes site/ or D:\
+                // the home.length + 1 is to account for the trailing slash, Linux uses / and Window uses \
                 new FolderTreeItem(this.client, file.name, file.path.substring(file.path.indexOf(home) + home.length + 1)) :
                 new FileTreeItem(this.client, file.name, file.path.substring(file.path.indexOf(home) + home.length + 1));
         });

--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -34,12 +34,12 @@ export class FolderTreeItem implements IAzureParentTreeItem {
         const httpResponse: kuduIncomingMessage = <kuduIncomingMessage>(await kuduClient.vfs.getItemWithHttpOperationResponse(this.folderPath)).response;
         // response contains a body with a JSON parseable string
         const fileList: kuduFile[] = <kuduFile[]>JSON.parse(httpResponse.body);
-        const home: string = this.client.kind.includes('linux') ? 'home/' : 'home\\';
+        const home: string = 'home';
         return fileList.map((file: kuduFile) => {
             return file.mime === 'inode/directory' ?
                 // truncate the home/ of the path
-                new FolderTreeItem(this.client, file.name, file.path.substring(file.path.indexOf(home) + home.length)) :
-                new FileTreeItem(this.client, file.name, file.path.substring(file.path.indexOf(home) + home.length));
+                new FolderTreeItem(this.client, file.name, file.path.substring(file.path.indexOf(home) + home.length + 1)) :
+                new FileTreeItem(this.client, file.name, file.path.substring(file.path.indexOf(home) + home.length + 1));
         });
     }
 }


### PR DESCRIPTION
Fixes #481 

Based on the app kind, the kudu url path uses either `/home` or `\home`.

I tested with Linux, Windows, and custom domains.

Linux app kind = 'linux'
Windows app kind = 'app'
Linux custom domain = 'app,linux'

The reason that I used include('linux') rather than === 'linux' is that custom domains will use `/home`.