### PR TITLE
Get rid of prompt and call enableScm for node projects

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,6 @@ export function getIgnoredFoldersForDeployment(runtime: string): string[] {
 
 export enum configurationSettings {
     zipIgnorePattern = 'zipIgnorePattern',
-    showBuildDuringDeployPrompt = 'showBuildDuringDeployPrompt',
     deploySubpath = 'deploySubpath',
     advancedCreation = 'advancedCreation'
 }


### PR DESCRIPTION
With the new quickCreation, we want to enableScmDeploy automatically if the newly created app has a node runtime.

This removes the prompt that we used to show users to enableScmDeploy.

Though I'd actually prefer to make an App Setting rather than using the .deployment file