### PR TITLE
Bump shared package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -705,7 +705,7 @@
         "portfinder": "^1.0.13",
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "~0.17.0",
+        "vscode-azureappservice": "~0.18.0",
         "vscode-azureextensionui": "~0.16.0",
         "vscode-azurekudu": "~0.1.6",
         "vscode-debugadapter": "^1.24.0",


### PR DESCRIPTION
This PR technically had minor breaking changes that required a bump of the minor version: https://github.com/Microsoft/vscode-azuretools/pull/218

However, no changes are required in this extension.