### PR TITLE
Moving deployment confirmation to before showing 'Deploying...'

### DIFF
--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
         "portfinder": "^1.0.13",
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "~0.18.0",
+        "vscode-azureappservice": "~0.19.0",
         "vscode-azureextensionui": "~0.16.0",
         "vscode-azurekudu": "~0.1.6",
         "vscode-debugadapter": "^1.24.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,3 +33,9 @@ export enum configurationSettings {
     advancedCreation = 'advancedCreation',
     defaultWebAppToDeploy = 'defaultWebAppToDeploy'
 }
+
+export enum ScmType {
+    None = 'None', // default scmType
+    LocalGit = 'LocalGit',
+    GitHub = 'GitHub'
+}


### PR DESCRIPTION
It just makes more sense to ask for confirmation before changing the node state to 'Deploying...' and before showing the long running notification. Also before the dialog to 'default' to this going forward