### PR TITLE
Refresh Deployment Slots node based on App Service Plan

### DIFF
--- a/src/explorer/WebAppProvider.ts
+++ b/src/explorer/WebAppProvider.ts
@@ -60,8 +60,7 @@ export class WebAppProvider implements IChildProvider {
             throw new UserCancelledError();
         } else {
             const siteClient: SiteClient = new SiteClient(newSite, node);
-            const appServicePlan: AppServicePlan = await siteClient.getAppServicePlan();
-            return new WebAppTreeItem(siteClient, appServicePlan);
+            return new WebAppTreeItem(siteClient);
         }
     }
 }

--- a/src/explorer/WebAppProvider.ts
+++ b/src/explorer/WebAppProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import WebSiteManagementClient = require('azure-arm-website');
-import { AppServicePlan, Site, WebAppCollection } from 'azure-arm-website/lib/models';
+import { Site, WebAppCollection } from 'azure-arm-website/lib/models';
 import { workspace, WorkspaceConfiguration } from 'vscode';
 import { createWebApp, SiteClient } from 'vscode-azureappservice';
 import { addExtensionUserAgent, IActionContext, IAzureNode, IAzureTreeItem, IChildProvider, UserCancelledError } from 'vscode-azureextensionui';
@@ -40,8 +40,7 @@ export class WebAppProvider implements IChildProvider {
                 try {
                     const siteClient: SiteClient = new SiteClient(s, node);
                     if (!siteClient.isFunctionApp) {
-                        const appServicePlan: AppServicePlan = await siteClient.getAppServicePlan();
-                        treeItems.push(new WebAppTreeItem(siteClient, appServicePlan));
+                        treeItems.push(new WebAppTreeItem(siteClient));
                     }
                 } catch {
                     if (s.name) {

--- a/src/explorer/WebAppTreeItem.ts
+++ b/src/explorer/WebAppTreeItem.ts
@@ -43,7 +43,7 @@ export class WebAppTreeItem extends SiteTreeItem {
     }
 
     public async loadMoreChildren(_parentNode: IAzureNode): Promise<IAzureTreeItem[]> {
-        const appServicePlan = await this.client.getAppServicePlan();
+        const appServicePlan: AppServicePlan = await this.client.getAppServicePlan();
         // tslint:disable-next-line:no-non-null-assertion
         const tier: string = String(appServicePlan.sku!.tier);
         // tslint:disable-next-line:no-non-null-assertion

--- a/src/explorer/WebAppTreeItem.ts
+++ b/src/explorer/WebAppTreeItem.ts
@@ -20,18 +20,14 @@ import { WebJobsTreeItem } from './WebJobsTreeItem';
 export class WebAppTreeItem extends SiteTreeItem {
     public static contextValue: string = extensionPrefix;
     public readonly contextValue: string = WebAppTreeItem.contextValue;
-    public readonly deploymentSlotsNode: IAzureTreeItem;
+    public deploymentSlotsNode: IAzureTreeItem;
     public readonly appSettingsNode: IAzureTreeItem;
     public readonly webJobsNode: IAzureTreeItem;
     public readonly folderNode: IAzureTreeItem;
     public readonly logFolderNode: IAzureTreeItem;
 
-    constructor(client: SiteClient, appServicePlan: AppServicePlan) {
+    constructor(client: SiteClient) {
         super(client);
-        // tslint:disable-next-line:no-non-null-assertion
-        const tier: string = String(appServicePlan.sku!.tier);
-        // tslint:disable-next-line:no-non-null-assertion
-        this.deploymentSlotsNode = /^(basic|free|shared)$/i.test(tier) ? new DeploymentSlotsNATreeItem(tier, appServicePlan.id!) : new DeploymentSlotsTreeItem(this.client);
         this.folderNode = new FolderTreeItem(this.client, 'Files', "/site/wwwroot", true);
         this.logFolderNode = new FolderTreeItem(this.client, 'Log Files', '/LogFiles', true);
         this.webJobsNode = new WebJobsTreeItem(this.client);
@@ -47,6 +43,11 @@ export class WebAppTreeItem extends SiteTreeItem {
     }
 
     public async loadMoreChildren(_parentNode: IAzureNode): Promise<IAzureTreeItem[]> {
+        const appServicePlan = await this.client.getAppServicePlan();
+        // tslint:disable-next-line:no-non-null-assertion
+        const tier: string = String(appServicePlan.sku!.tier);
+        // tslint:disable-next-line:no-non-null-assertion
+        this.deploymentSlotsNode = /^(basic|free|shared)$/i.test(tier) ? new DeploymentSlotsNATreeItem(tier, appServicePlan.id!) : new DeploymentSlotsTreeItem(this.client);
         return [this.deploymentSlotsNode, this.folderNode, this.logFolderNode, this.webJobsNode, this.appSettingsNode];
     }
 


### PR DESCRIPTION
I don't prefer this solution, but couldn't really think of a way around it.  We need to check to see if the asp tier has changed every time the Web App is refreshed to detect whether or not we should change the Deployment Slots node so it makes sense to do it in LoadMoreChildren.

I'd want to logic to be handled in the Deployment Slots tree item, but I don't think a node can delete/alter itself and must be handled by the parent node.  If anybody knows how to do that, please let me know!

Fixes https://github.com/Microsoft/vscode-azureappservice/issues/531