### PR TITLE
Ensure the Microsoft.Web provider is registered

### DIFF
--- a/package.json
+++ b/package.json
@@ -762,7 +762,7 @@
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
         "vscode-azureappservice": "^0.20.0",
-        "vscode-azureextensionui": "^0.17.0",
+        "vscode-azureextensionui": "^0.17.1",
         "vscode-azurekudu": "^0.1.8",
         "vscode-debugadapter": "^1.24.0",
         "vscode-debugprotocol": "^1.24.0",

--- a/src/explorer/WebAppProvider.ts
+++ b/src/explorer/WebAppProvider.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ResourceManagementClient } from 'azure-arm-resource';
+import { Provider } from 'azure-arm-resource/lib/resource/models';
 import { WebSiteManagementClient } from 'azure-arm-website';
 import { Site, WebAppCollection } from 'azure-arm-website/lib/models';
 import { workspace, WorkspaceConfiguration } from 'vscode';
 import { createWebApp, SiteClient } from 'vscode-azureappservice';
-import { addExtensionUserAgent, IActionContext, IAzureNode, IAzureTreeItem, IChildProvider, UserCancelledError } from 'vscode-azureextensionui';
+import { addExtensionUserAgent, callWithTelemetryAndErrorHandling, createAzureClient, IActionContext, IAzureNode, IAzureTreeItem, IChildProvider, UserCancelledError } from 'vscode-azureextensionui';
 import { configurationSettings, extensionPrefix } from '../constants';
 import { InvalidWebAppTreeItem } from './InvalidWebAppTreeItem';
 import { WebAppTreeItem } from './WebAppTreeItem';
@@ -16,12 +18,15 @@ export class WebAppProvider implements IChildProvider {
     public readonly childTypeLabel: string = 'Web App';
 
     private _nextLink: string | undefined;
+    private _verifiedSubscriptions: string[] = [];
 
     public hasMoreChildren(): boolean {
         return this._nextLink !== undefined;
     }
 
     public async loadMoreChildren(node: IAzureNode, clearCache: boolean): Promise<IAzureTreeItem[]> {
+        await this.ensureProviderRegistered(node);
+
         if (clearCache) {
             this._nextLink = undefined;
         }
@@ -52,6 +57,8 @@ export class WebAppProvider implements IChildProvider {
     }
 
     public async createChild(node: IAzureNode<IAzureTreeItem>, showCreatingNode: (label: string) => void, actionContext: IActionContext): Promise<IAzureTreeItem> {
+        await this.ensureProviderRegistered(node);
+
         const workspaceConfig: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
         const advancedCreation: boolean | undefined = workspaceConfig.get(configurationSettings.advancedCreation);
         const newSite: Site | undefined = await createWebApp(actionContext, node, showCreatingNode, advancedCreation);
@@ -60,6 +67,25 @@ export class WebAppProvider implements IChildProvider {
         } else {
             const siteClient: SiteClient = new SiteClient(newSite, node);
             return new WebAppTreeItem(siteClient);
+        }
+    }
+
+    private async ensureProviderRegistered(node: IAzureNode): Promise<void> {
+        if (!this._verifiedSubscriptions.some((id: string) => node.subscriptionId === id)) {
+            // Hide errors from this check and mark subscription as 'verified' even if it fails
+            // For example, maybe the user doesn't have permissions to view providers on this subscription, but the provider has already been registered
+            await callWithTelemetryAndErrorHandling('appService.ensureProviderRegistered', async function (this: IActionContext): Promise<void> {
+                this.suppressErrorDisplay = true;
+
+                const resourceClient: ResourceManagementClient = createAzureClient(node, ResourceManagementClient);
+                const providerName: string = 'Microsoft.Web';
+                const provider: Provider = await resourceClient.providers.get(providerName);
+                if (!provider.registrationState || provider.registrationState.toLowerCase() === 'unregistered') {
+                    await resourceClient.providers.register(providerName);
+                }
+            });
+
+            this._verifiedSubscriptions.push(node.subscriptionId);
         }
     }
 }


### PR DESCRIPTION
While following the App Service tutorial, new users were often getting an error like "Cannot find subscription with name". It turns out we have to make sure the 'Microsoft.Web' provider is registered.

Fixes #419