### PR TITLE
Fix for checking for support for remote debugging

### DIFF
--- a/src/commands/remoteDebug/remoteDebugCommon.ts
+++ b/src/commands/remoteDebug/remoteDebugCommon.ts
@@ -17,7 +17,7 @@ export function reportMessage(message: string, progress: vscode.Progress<{}>): v
 
 export function checkForRemoteDebugSupport(siteConfig: SiteConfigResource): void {
     // So far only node on linux is supported
-    if (siteConfig.linuxFxVersion && !siteConfig.linuxFxVersion.toLowerCase().startsWith('node')) {
+    if (!siteConfig.linuxFxVersion || !siteConfig.linuxFxVersion.toLowerCase().startsWith('node')) {
         throw new Error('Azure Remote Debugging is currently only supported for node on Linux.');
     }
 }


### PR DESCRIPTION
Addresses Microsoft/vscode-azureappservice#571

Checking for remote debugging support was failing for Windows web apps where "linuxFxVersion" config setting is empty.