### PR TITLE
Remove sovereign support from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to the "azure-appservice" extension will be documented in th
 ## 0.9.1 - 2018-09-06
 ### Added
 - Support for .jar deployment
-- Soverign account support
 - Shortcut key for Azure View
 
 ### Fixed


### PR DESCRIPTION
It's not documented or official in the azure account extension, so I don't want to "advertise" support until that's done: https://github.com/Microsoft/vscode-azure-account (even if it does work unofficially)

Also this way we don't have to test it for the upcoming bug fix release :)