### PR TITLE
Remove duplicate " - Log Stream"

### DIFF
--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -35,7 +35,7 @@ export abstract class SiteTreeItem implements IAzureParentTreeItem {
     }
 
     public get logStreamLabel(): string {
-        return `${this.client.fullName} - Log Stream`;
+        return this.client.fullName;
     }
 
     public async refreshLabel(): Promise<void> {


### PR DESCRIPTION
The shared package is also adding " - Log Stream" [here](https://github.com/Microsoft/vscode-azuretools/blob/master/appservice/src/startStreamingLogs.ts#L41), so there's no reason to do it in this extension. Functions does not have this problem.