### PR TITLE
Fix refreshLabel due to new tree

### DIFF
--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -42,7 +42,7 @@ export abstract class SiteTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         return this.root.client.fullName;
     }
 
-    public async refreshLabel(): Promise<void> {
+    public async refreshLabelImpl(): Promise<void> {
         try {
             this._state = await this.root.client.getState();
         } catch {


### PR DESCRIPTION
Realized I forgot to change this when working on Cosmos DB.

As a reminder: the new tree suffixes methods with "Impl" if that method should be implemented, but not called directly (other than by the base class).