### PR TITLE
Update to latest UI package

### DIFF
--- a/package.json
+++ b/package.json
@@ -869,8 +869,8 @@
         "portfinder": "^1.0.13",
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "^0.24.1",
-        "vscode-azureextensionui": "^0.18.6",
+        "vscode-azureappservice": "^0.25.0",
+        "vscode-azureextensionui": "^0.19.0",
         "vscode-azurekudu": "^0.1.8",
         "vscode-debugadapter": "^1.24.0",
         "vscode-debugprotocol": "^1.24.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,11 +175,11 @@ export function activate(context: vscode.ExtensionContext): void {
     registerCommand('appService.Deploy', async function (this: IActionContext, target?: vscode.Uri | WebAppTreeItem | undefined): Promise<void> {
         await deploy(this, true, target);
     });
-    registerCommand('appService.ConfigureDeploymentSource', async (node?: SiteTreeItem) => {
+    registerCommand('appService.ConfigureDeploymentSource', async function (this: IActionContext, node?: SiteTreeItem): Promise<void> {
         if (!node) {
             node = <SiteTreeItem>await tree.showTreeItemPicker(WebAppTreeItem.contextValue);
         }
-        await editScmType(node.root.client, node);
+        await editScmType(node.root.client, node, this);
     });
     registerCommand('appService.OpenVSTSCD', async (node?: WebAppTreeItem) => {
         if (!node) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,8 +39,6 @@ import { LogpointsCollection } from './logPoints/structs/LogpointsCollection';
 // tslint:disable-next-line:export-name
 // tslint:disable-next-line:max-func-body-length
 export function activate(context: vscode.ExtensionContext): void {
-    registerUIExtensionVariables(ext);
-    registerAppServiceExtensionVariables(ext);
     ext.context = context;
     ext.reporter = createTelemetryReporter(context);
 
@@ -49,6 +47,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
     ext.outputChannel = vscode.window.createOutputChannel("Azure App Service");
     context.subscriptions.push(ext.outputChannel);
+
+    registerUIExtensionVariables(ext);
+    registerAppServiceExtensionVariables(ext);
 
     const tree = new AzureTreeDataProvider(WebAppProvider, 'appService.LoadMore');
     ext.tree = tree;


### PR DESCRIPTION
There was a breaking change where we have to change the order of how we call `registerUIExtensionVariables`. Depends on https://github.com/Microsoft/vscode-azuretools/pull/313