### PR TITLE
Add support for account-level connection strings

### DIFF
--- a/src/commands/connections/IConnections.ts
+++ b/src/commands/connections/IConnections.ts
@@ -1,9 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-export interface IConnections {
-    webAppId: string;
-    cosmosDB?: string[];
-}

--- a/src/explorer/CosmosDBTreeItem.ts
+++ b/src/explorer/CosmosDBTreeItem.ts
@@ -110,7 +110,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         // Don't wait
         vscode.window.showInformationMessage(`Database "${createdDatabase.label}" connected to web app "${this.root.client.fullName}". Created "${appSettingKeyToAdd}" application settings.`, ok, revealDatabase).then(async (result: vscode.MessageItem | undefined) => {
             if (result === revealDatabase) {
-                await createdDatabase.databaseTreeItem.reveal();
+                await createdDatabase.cosmosExtensionItem.reveal();
             }
         });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -321,7 +321,7 @@ export function activate(context: vscode.ExtensionContext): void {
     });
     registerCommand('appService.AddCosmosDBConnection', addCosmosDBConnection);
     registerCommand('appService.RemoveCosmosDBConnection', removeCosmosDBConnection);
-    registerCommand('appService.RevealConnection', async (node: CosmosDBConnection) => await node.databaseTreeItem.reveal());
+    registerCommand('appService.RevealConnection', async (node: CosmosDBConnection) => await node.cosmosExtensionItem.reveal());
     registerCommand('appService.RevealConnectionInAppSettings', revealConnectionInAppSettings);
 }
 

--- a/src/vscode-cosmos.api.d.ts
+++ b/src/vscode-cosmos.api.d.ts
@@ -12,7 +12,7 @@ export interface CosmosDBExtensionApi {
      *
      * @param query The query object to use for the find
      */
-    findTreeItem(query: TreeItemQuery): Promise<DatabaseTreeItem | undefined>;
+    findTreeItem(query: TreeItemQuery): Promise<DatabaseAccountTreeItem | DatabaseTreeItem | undefined>;
 
     /**
      * Prompts the user to pick an item from the Cosmos DB tree


### PR DESCRIPTION
I think database-level connection strings will more common, but you never know what users will put in their application settings. The only real difference is the label we show.

Also delete an unused file.