### PR TITLE
Add support for DocDB connections

### DIFF
--- a/src/commands/connections/revealConnectionInAppSettings.ts
+++ b/src/commands/connections/revealConnectionInAppSettings.ts
@@ -7,9 +7,11 @@ import { CosmosDBConnection } from '../../explorer/CosmosDBConnection';
 import { ext } from "../../extensionVariables";
 
 export async function revealConnectionInAppSettings(node: CosmosDBConnection): Promise<void> {
-    const nodeToReveal = await ext.tree.findTreeItem(`${node.parent.parent.parent.appSettingsNode.fullId}/${node.appSettingKey}`);
+    // Ideally this reveals all appSettingKeys, but for now just reveal the first one
+    const firstKey: string = node.appSettingKeys[0];
+    const nodeToReveal = await ext.tree.findTreeItem(`${node.parent.parent.parent.appSettingsNode.fullId}/${firstKey}`);
     if (!nodeToReveal) {
-        throw new Error(`Failed to find app setting with "${node.appSettingKey}" key.`);
+        throw new Error(`Failed to find app setting with key "${firstKey}".`);
     }
     await ext.treeView.reveal(nodeToReveal);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,7 +33,6 @@ export enum configurationSettings {
     deploySubpath = 'deploySubpath',
     advancedCreation = 'advancedCreation',
     defaultWebAppToDeploy = 'defaultWebAppToDeploy',
-    enableConnectionsNode = 'enableConnectionsNode',
     connections = 'connections'
 }
 

--- a/src/explorer/WebAppTreeItem.ts
+++ b/src/explorer/WebAppTreeItem.ts
@@ -10,7 +10,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { AppSettingsTreeItem, AppSettingTreeItem, DeploymentsTreeItem, DeploymentTreeItem, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
 import { AzureParentTreeItem, AzureTreeItem, createAzureClient } from 'vscode-azureextensionui';
-import * as constants from '../constants';
 import { extensionPrefix } from '../constants';
 import { ConnectionsTreeItem } from './ConnectionsTreeItem';
 import { DeploymentSlotsNATreeItem, DeploymentSlotsTreeItem } from './DeploymentSlotsTreeItem';
@@ -54,12 +53,7 @@ export class WebAppTreeItem extends SiteTreeItem {
         this.deploymentsNode = new DeploymentsTreeItem(this, siteConfig);
         // tslint:disable-next-line:no-non-null-assertion
         this.deploymentSlotsNode = tier && /^(basic|free|shared)$/i.test(tier) ? new DeploymentSlotsNATreeItem(this, tier, asp!.id!) : new DeploymentSlotsTreeItem(this);
-        const nodes: AzureTreeItem<ISiteTreeRoot>[] = [this.deploymentSlotsNode, this.folderNode, this.logFolderNode, this.webJobsNode, this.appSettingsNode, this.deploymentsNode];
-        const workspaceConfig = vscode.workspace.getConfiguration(constants.extensionPrefix);
-        if (workspaceConfig.get(constants.configurationSettings.enableConnectionsNode)) {
-            nodes.push(this.connectionsNode);
-        }
-        return nodes;
+        return [this.deploymentSlotsNode, this.folderNode, this.logFolderNode, this.webJobsNode, this.appSettingsNode, this.deploymentsNode, this.connectionsNode];
     }
 
     public pickTreeItemImpl(expectedContextValue: string): AzureTreeItem<ISiteTreeRoot> | undefined {

--- a/src/vscode-cosmos.api.d.ts
+++ b/src/vscode-cosmos.api.d.ts
@@ -41,6 +41,11 @@ export interface DatabaseAccountTreeItem extends CosmosDBTreeItem {
     azureData?: {
         accountName: string;
     }
+
+    docDBData?: {
+        masterKey: string;
+        documentEndpoint: string;
+    }
 }
 
 export interface DatabaseTreeItem extends DatabaseAccountTreeItem {


### PR DESCRIPTION
Currently it's pretty strict in terms of how it "detects" a DocDB connection. It has to find an app setting that ends in "_ENDPOINT" and an app setting that ends in "_MASTER_KEY" and they have to have the same prefix. I figure that's a good starting point and we can improve/change the detection in the future.

Relies on this PR in Cosmos: https://github.com/Microsoft/vscode-cosmosdb/pull/946

Also removed the feature flag since this was the biggest piece missing.

Only thing I didn't implement was "Delete connection", but I filed this issue to do it separately: https://github.com/Microsoft/vscode-azureappservice/issues/708