### PR TITLE
Only allow one remote debugging session + other improvements

### DIFF
--- a/src/commands/remoteDebug/startRemoteDebug.ts
+++ b/src/commands/remoteDebug/startRemoteDebug.ts
@@ -17,7 +17,7 @@ let isRemoteDebugging = false;
 
 export async function startRemoteDebug(actionContext: IActionContext, node?: SiteTreeItem): Promise<void> {
     if (isRemoteDebugging) {
-        throw new Error('Azure Remote Debugging is already started.');
+        throw new Error('Azure Remote Debugging is currently starting or already started.');
     }
 
     isRemoteDebugging = true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -291,8 +291,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<AzureE
 
         registerCommand('appService.LogPoints.OpenScript', openScript);
 
-        registerCommand('appService.StartRemoteDebug', async (node?: SiteTreeItem) => startRemoteDebug(node));
-        registerCommand('appService.DisableRemoteDebug', async (node?: SiteTreeItem) => disableRemoteDebug(node));
+        registerCommand('appService.StartRemoteDebug', async function (this: IActionContext, node?: SiteTreeItem): Promise<void> { await startRemoteDebug(this, node); });
+        registerCommand('appService.DisableRemoteDebug', async function (this: IActionContext, node?: SiteTreeItem): Promise<void> { await disableRemoteDebug(this, node); });
 
         registerCommand('appService.showFile', async (node: FileTreeItem) => { await showFile(node, fileEditor); }, 500);
         registerCommand('appService.ScaleUp', async (node: DeploymentSlotsNATreeItem | ScaleUpTreeItem) => {


### PR DESCRIPTION
Addressing #707 with a very simple approach. Is there any better way to do this?

Also:
- Move remote debugging messaging to ProgressLocation.Notification so that it is more obvious for the user to see that something is happening.
- Add version of AppService container to telemetry to give better insight into which users are having issues.