### PR TITLE
Leverage debounce property in registerCommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -928,7 +928,7 @@
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
         "vscode-azureappservice": "^0.25.2",
-        "vscode-azureextensionui": "^0.19.0",
+        "vscode-azureextensionui": "^0.19.2",
         "vscode-azurekudu": "^0.1.8",
         "vscode-debugadapter": "^1.24.0",
         "vscode-debugprotocol": "^1.24.0"

--- a/package.json
+++ b/package.json
@@ -927,7 +927,7 @@
         "portfinder": "^1.0.13",
         "request": "^2.83.0",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "^0.25.1",
+        "vscode-azureappservice": "^0.25.2",
         "vscode-azureextensionui": "^0.19.0",
         "vscode-azurekudu": "^0.1.8",
         "vscode-debugadapter": "^1.24.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -285,20 +285,7 @@ export function activate(context: vscode.ExtensionContext): void {
     registerCommand('appService.StartRemoteDebug', async (node?: SiteTreeItem) => startRemoteDebug(node));
     registerCommand('appService.DisableRemoteDebug', async (node?: SiteTreeItem) => disableRemoteDebug(node));
 
-    registerCommand('appService.showFile', async (node: FileTreeItem) => {
-        const logFiles: string = 'LogFiles/';
-        // we don't want to let users save log files, so rather than using the FileEditor, just open an untitled document
-        if (node.path.startsWith(logFiles)) {
-            const file: IFileResult = await getFile(node.root.client, node.path);
-            const document: vscode.TextDocument = await vscode.workspace.openTextDocument({
-                language: extname(node.path).substring(1), // remove the prepending dot of the ext
-                content: file.data
-            });
-            await vscode.window.showTextDocument(document);
-        } else {
-            await fileEditor.showEditor(node);
-        }
-    });
+    registerCommand('appService.showFile', async (node: FileTreeItem) => { await showFile(node, fileEditor); }, 500);
     registerCommand('appService.ScaleUp', async (node: DeploymentSlotsNATreeItem | ScaleUpTreeItem) => {
         node.openInPortal(node.scaleUpId);
     });


### PR DESCRIPTION
Fixes #611 

Uses debounce property in registerCommand to prevent users from spam clicking and firing the same command rapidly

Also fixes bugs dealing with `instanceof`