### PR TITLE
Add deployments to DeploymentSlot treeItems

### DIFF
--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -23,7 +23,6 @@ export class DeploymentSlotTreeItem extends SiteTreeItem {
         this.folderNode = new FolderTreeItem(this, 'Files', "/site/wwwroot");
         this.logFolderNode = new FolderTreeItem(this, 'Logs', '/LogFiles', 'logFolder');
         this.appSettingsNode = new AppSettingsTreeItem(this);
-
     }
 
     public get iconPath(): { light: string, dark: string } {

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -11,13 +11,6 @@ import { FolderTreeItem } from './FolderTreeItem';
 import { SiteTreeItem } from './SiteTreeItem';
 
 export class DeploymentSlotTreeItem extends SiteTreeItem {
-
-    public get iconPath(): { light: string, dark: string } {
-        return {
-            light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'DeploymentSlot_color.svg'),
-            dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'DeploymentSlot_color.svg')
-        };
-    }
     public static contextValue: string = 'deploymentSlot';
     public readonly contextValue: string = DeploymentSlotTreeItem.contextValue;
     public deploymentsNode: DeploymentsTreeItem | undefined;
@@ -31,6 +24,13 @@ export class DeploymentSlotTreeItem extends SiteTreeItem {
         this.logFolderNode = new FolderTreeItem(this, 'Logs', '/LogFiles', 'logFolder');
         this.appSettingsNode = new AppSettingsTreeItem(this);
 
+    }
+
+    public get iconPath(): { light: string, dark: string } {
+        return {
+            light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'DeploymentSlot_color.svg'),
+            dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'DeploymentSlot_color.svg')
+        };
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzureParentTreeItem<ISiteTreeRoot>[]> {

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -3,15 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SiteConfig } from 'azure-arm-website/lib/models';
 import * as path from 'path';
-import { AppSettingsTreeItem, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
+import { AppSettingsTreeItem, DeploymentsTreeItem, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
 import { AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
 import { FolderTreeItem } from './FolderTreeItem';
 import { SiteTreeItem } from './SiteTreeItem';
 
 export class DeploymentSlotTreeItem extends SiteTreeItem {
+
+    public get iconPath(): { light: string, dark: string } {
+        return {
+            light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'DeploymentSlot_color.svg'),
+            dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'DeploymentSlot_color.svg')
+        };
+    }
     public static contextValue: string = 'deploymentSlot';
     public readonly contextValue: string = DeploymentSlotTreeItem.contextValue;
+    public deploymentsNode: DeploymentsTreeItem | undefined;
     private readonly appSettingsNode: AppSettingsTreeItem;
     private readonly folderNode: FolderTreeItem;
     private readonly logFolderNode: FolderTreeItem;
@@ -21,17 +30,13 @@ export class DeploymentSlotTreeItem extends SiteTreeItem {
         this.folderNode = new FolderTreeItem(this, 'Files', "/site/wwwroot");
         this.logFolderNode = new FolderTreeItem(this, 'Logs', '/LogFiles', 'logFolder');
         this.appSettingsNode = new AppSettingsTreeItem(this);
-    }
 
-    public get iconPath(): { light: string, dark: string } {
-        return {
-            light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'DeploymentSlot_color.svg'),
-            dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'DeploymentSlot_color.svg')
-        };
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzureParentTreeItem<ISiteTreeRoot>[]> {
-        return [this.folderNode, this.logFolderNode, this.appSettingsNode];
+        const siteConfig: SiteConfig = await this.root.client.getSiteConfig();
+        this.deploymentsNode = new DeploymentsTreeItem(this, siteConfig);
+        return [this.folderNode, this.logFolderNode, this.appSettingsNode, this.deploymentsNode];
     }
 
     public pickTreeItemImpl(expectedContextValue: string): AzureTreeItem<ISiteTreeRoot> | undefined {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/700

Seems like Deployments works for Deployment Slots just fine.  I was able to connect, redeploy, view logs, and disconnect with no issues.  Command palette doesn't work, of course, but I don't think we were expecting palette support for slots.

![image](https://user-images.githubusercontent.com/5290572/48735876-2ee19380-ec0f-11e8-92ce-1e21ac58a81b.png)

