### PR TITLE
Fix sort and icons for folders

### DIFF
--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -71,10 +71,10 @@ export class FolderTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
 }
 
 // tslint:disable-next-line:no-any
-function instanceOfCompare<T>(ti1: AzureTreeItem, ti2: AzureTreeItem, type1: new (...args: any[]) => T): number | undefined {
-    if (!(ti1 instanceof type1) && ti2 instanceof type1) {
+function instanceOfCompare<T>(ti1: AzureTreeItem, ti2: AzureTreeItem, typeToCompare: new (...args: any[]) => T): number | undefined {
+    if (!(ti1 instanceof typeToCompare) && ti2 instanceof typeToCompare) {
         return 1;
-    } else if (ti1 instanceof type1 && !(ti2 instanceof type1)) {
+    } else if (ti1 instanceof typeToCompare && !(ti2 instanceof typeToCompare)) {
         return -1;
     } else {
         return undefined;

--- a/src/explorer/FolderTreeItem.ts
+++ b/src/explorer/FolderTreeItem.ts
@@ -22,10 +22,10 @@ export class FolderTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public get iconPath(): { light: string, dark: string } | undefined {
-        return this.contextValue === 'subFolder' ? undefined : {
+        return {
             light: path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'Folder_16x.svg'),
             dark: path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'Folder_16x.svg')
-        }; // no icons for subfolders
+        };
     }
 
     public hasMoreChildrenImpl(): boolean {
@@ -60,13 +60,24 @@ export class FolderTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public compareChildrenImpl(ti1: AzureTreeItem<ISiteTreeRoot>, ti2: AzureTreeItem<ISiteTreeRoot>): number {
-        if (!(ti1 instanceof LogStreamTreeItem) && ti2 instanceof LogStreamTreeItem) {
-            return 1;
+        let result: number | undefined = instanceOfCompare(ti1, ti2, LogStreamTreeItem);
+
+        if (result === undefined) {
+            result = instanceOfCompare(ti1, ti2, FolderTreeItem);
         }
-        if (ti1 instanceof LogStreamTreeItem && !(ti2 instanceof LogStreamTreeItem)) {
-            return -1;
-        }
-        return ti1.label.localeCompare(ti2.label);
+
+        return result === undefined ? ti1.label.localeCompare(ti2.label) : result;
+    }
+}
+
+// tslint:disable-next-line:no-any
+function instanceOfCompare<T>(ti1: AzureTreeItem, ti2: AzureTreeItem, type1: new (...args: any[]) => T): number | undefined {
+    if (!(ti1 instanceof type1) && ti2 instanceof type1) {
+        return 1;
+    } else if (ti1 instanceof type1 && !(ti2 instanceof type1)) {
+        return -1;
+    } else {
+        return undefined;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azureappservice/issues/631

Puts folders above files. Also adds icons to subFolders. I know @nturinski didn't use icons for subFolders to match VS Code's file explorer, but I just don't think it's worth it given the alignment issues.

Icon before:
<img width="135" alt="screen shot 2018-11-19 at 5 39 30 pm" src="https://user-images.githubusercontent.com/11282622/48742291-f5675300-ec23-11e8-9048-4fd6082ca1b2.png">

Icon after:
<img width="104" alt="screen shot 2018-11-19 at 5 40 44 pm" src="https://user-images.githubusercontent.com/11282622/48742297-fac49d80-ec23-11e8-84b6-a120156b955d.png">

"settings.json" should definitely be indented _more_ than ".gitignore"