### PR TITLE
Update package-lock and fix growl warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.10.38"
+                "@types/node": "*"
             }
         },
         "@types/fs-extra": {
@@ -31,13 +31,13 @@
             "integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.10.38"
+                "@types/node": "*"
             }
         },
         "@types/mocha": {
-            "version": "2.2.48",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-            "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
+            "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
             "dev": true
         },
         "@types/node": {
@@ -51,10 +51,10 @@
             "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
             "dev": true,
             "requires": {
-                "@types/caseless": "0.12.1",
-                "@types/form-data": "2.2.1",
-                "@types/node": "8.10.38",
-                "@types/tough-cookie": "2.3.4"
+                "@types/caseless": "*",
+                "@types/form-data": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*"
             }
         },
         "@types/request-promise": {
@@ -63,8 +63,8 @@
             "integrity": "sha512-qlx6COxSTdSFHY9oX9v2zL1I05hgz5lwqYiXa2SFL2nDxAiG5KK8rnllLBH7k6OqzS3Ck0bWbxlGVdrZhS6oNw==",
             "dev": true,
             "requires": {
-                "@types/bluebird": "3.5.24",
-                "@types/request": "2.48.1"
+                "@types/bluebird": "*",
+                "@types/request": "*"
             }
         },
         "@types/tough-cookie": {
@@ -78,15 +78,15 @@
             "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
             "integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
             "requires": {
-                "@types/node": "8.10.38",
-                "async": "2.6.0",
-                "date-utils": "1.2.21",
-                "jws": "3.1.5",
-                "request": "2.88.0",
-                "underscore": "1.9.1",
-                "uuid": "3.3.2",
-                "xmldom": "0.1.27",
-                "xpath.js": "1.1.0"
+                "@types/node": "^8.0.47",
+                "async": ">=0.6.0",
+                "date-utils": "*",
+                "jws": "3.x.x",
+                "request": ">= 2.52.0",
+                "underscore": ">= 1.3.1",
+                "uuid": "^3.1.0",
+                "xmldom": ">= 0.1.x",
+                "xpath.js": "~1.1.0"
             }
         },
         "ajv": {
@@ -94,10 +94,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
             "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
             "requires": {
-                "fast-deep-equal": "2.0.1",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.4.1",
-                "uri-js": "4.2.2"
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ansi-colors": {
@@ -106,7 +106,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -160,7 +160,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "applicationinsights": {
@@ -179,7 +179,7 @@
             "integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
             "dev": true,
             "requires": {
-                "file-type": "4.4.0"
+                "file-type": "^4.2.0"
             }
         },
         "archiver": {
@@ -187,14 +187,14 @@
             "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
             "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
             "requires": {
-                "archiver-utils": "1.3.0",
-                "async": "2.6.0",
-                "buffer-crc32": "0.2.13",
-                "glob": "7.1.3",
-                "lodash": "4.17.11",
-                "readable-stream": "2.3.6",
-                "tar-stream": "1.6.2",
-                "zip-stream": "1.2.0"
+                "archiver-utils": "^1.3.0",
+                "async": "^2.0.0",
+                "buffer-crc32": "^0.2.1",
+                "glob": "^7.0.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0",
+                "tar-stream": "^1.5.0",
+                "zip-stream": "^1.2.0"
             }
         },
         "archiver-utils": {
@@ -202,12 +202,12 @@
             "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
             "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
             "requires": {
-                "glob": "7.1.3",
-                "graceful-fs": "4.1.15",
-                "lazystream": "1.0.0",
-                "lodash": "4.17.11",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "glob": "^7.0.0",
+                "graceful-fs": "^4.1.0",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.8.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "archy": {
@@ -222,7 +222,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -267,7 +267,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -293,7 +293,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "assert-plus": {
@@ -312,7 +312,7 @@
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.14.0"
             }
         },
         "asynckit": {
@@ -341,8 +341,8 @@
             "resolved": "https://registry.npmjs.org/azure-arm-resource/-/azure-arm-resource-3.0.0-preview.tgz",
             "integrity": "sha512-5AxK9Nnk9hRDtyiXkaqvHV2BvII12JpPpTTHL8p9ZKgkwy67mWk+repoe9PnjxwG2Rm1RadutonccynJ+VHVAw==",
             "requires": {
-                "ms-rest": "2.3.8",
-                "ms-rest-azure": "2.5.9"
+                "ms-rest": "^2.0.0",
+                "ms-rest-azure": "^2.0.0"
             }
         },
         "azure-arm-storage": {
@@ -350,8 +350,8 @@
             "resolved": "https://registry.npmjs.org/azure-arm-storage/-/azure-arm-storage-3.2.0.tgz",
             "integrity": "sha512-jrew8qgqCiJ66QyjAhQis7AXhK6hp5soypvcxio3g/b1mNJr7RsQ6vD5zBRebcvM+QBGzvv7COiXy/xzibyOgA==",
             "requires": {
-                "ms-rest": "2.3.8",
-                "ms-rest-azure": "2.5.9"
+                "ms-rest": "^2.2.2",
+                "ms-rest-azure": "^2.3.3"
             }
         },
         "azure-arm-website": {
@@ -359,8 +359,8 @@
             "resolved": "https://registry.npmjs.org/azure-arm-website/-/azure-arm-website-5.7.0.tgz",
             "integrity": "sha512-GnwqaelTIhv40YI3Ch8+Q272X6XXWTq99Y1aYWZb1cejSP4gjrWWeppwor4HtjlVU9i9YIvYO91TRjQt8FrHVA==",
             "requires": {
-                "ms-rest": "2.3.8",
-                "ms-rest-azure": "2.5.9"
+                "ms-rest": "^2.3.3",
+                "ms-rest-azure": "^2.5.5"
             }
         },
         "azure-storage": {
@@ -368,17 +368,17 @@
             "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.2.tgz",
             "integrity": "sha512-pOyGPya9+NDpAfm5YcFfklo57HfjDbYLXxs4lomPwvRxmb0Di/A+a+RkUmEFzaQ8S13CqxK40bRRB0sjj2ZQxA==",
             "requires": {
-                "browserify-mime": "1.2.9",
-                "extend": "3.0.2",
+                "browserify-mime": "~1.2.9",
+                "extend": "^3.0.2",
                 "json-edm-parser": "0.1.2",
                 "md5.js": "1.3.4",
-                "readable-stream": "2.0.6",
-                "request": "2.88.0",
-                "underscore": "1.8.3",
-                "uuid": "3.3.2",
-                "validator": "9.4.1",
+                "readable-stream": "~2.0.0",
+                "request": "^2.86.0",
+                "underscore": "~1.8.3",
+                "uuid": "^3.0.0",
+                "validator": "~9.4.1",
                 "xml2js": "0.2.8",
-                "xmlbuilder": "9.0.7"
+                "xmlbuilder": "^9.0.7"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -391,12 +391,12 @@
                     "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -417,9 +417,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "balanced-match": {
@@ -433,13 +433,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -448,7 +448,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -457,7 +457,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -466,7 +466,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -475,9 +475,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -492,7 +492,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -506,8 +506,8 @@
             "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "requires": {
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2"
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
             }
         },
         "block-stream": {
@@ -516,7 +516,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -535,7 +535,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -545,16 +545,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.3",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -563,7 +563,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -584,8 +584,8 @@
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
             "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
             "requires": {
-                "base64-js": "1.3.0",
-                "ieee754": "1.1.12"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
             }
         },
         "buffer-alloc": {
@@ -593,8 +593,8 @@
             "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "requires": {
-                "buffer-alloc-unsafe": "1.1.0",
-                "buffer-fill": "1.0.0"
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -641,15 +641,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "caseless": {
@@ -663,11 +663,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "charenc": {
@@ -682,12 +682,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.2",
-                "htmlparser2": "3.10.0",
-                "lodash": "4.17.11",
-                "parse5": "3.0.3"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "class-utils": {
@@ -696,10 +696,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -708,7 +708,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -737,9 +737,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "collection-visit": {
@@ -748,8 +748,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -778,7 +778,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -787,7 +787,7 @@
             "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
             "dev": true,
             "requires": {
-                "graceful-readlink": "1.0.1"
+                "graceful-readlink": ">= 1.0.0"
             }
         },
         "component-emitter": {
@@ -801,10 +801,10 @@
             "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
             "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "crc32-stream": "2.0.0",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "buffer-crc32": "^0.2.1",
+                "crc32-stream": "^2.0.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "concat-map": {
@@ -818,7 +818,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.1"
             }
         },
         "copy-descriptor": {
@@ -837,7 +837,7 @@
             "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
             "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
             "requires": {
-                "buffer": "5.2.1"
+                "buffer": "^5.1.0"
             }
         },
         "crc32-stream": {
@@ -845,8 +845,8 @@
             "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
             "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
             "requires": {
-                "crc": "3.8.0",
-                "readable-stream": "2.3.6"
+                "crc": "^3.4.4",
+                "readable-stream": "^2.0.0"
             }
         },
         "crypt": {
@@ -861,10 +861,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.2",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.2"
+                "nth-check": "~1.0.1"
             }
         },
         "css-what": {
@@ -878,7 +878,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "date-utils": {
@@ -912,14 +912,14 @@
             "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
             "dev": true,
             "requires": {
-                "decompress-tar": "4.1.1",
-                "decompress-tarbz2": "4.1.1",
-                "decompress-targz": "4.1.1",
-                "decompress-unzip": "4.0.1",
-                "graceful-fs": "4.1.15",
-                "make-dir": "1.3.0",
-                "pify": "2.3.0",
-                "strip-dirs": "2.1.0"
+                "decompress-tar": "^4.0.0",
+                "decompress-tarbz2": "^4.0.0",
+                "decompress-targz": "^4.0.0",
+                "decompress-unzip": "^4.0.1",
+                "graceful-fs": "^4.1.10",
+                "make-dir": "^1.0.0",
+                "pify": "^2.3.0",
+                "strip-dirs": "^2.0.0"
             }
         },
         "decompress-tar": {
@@ -928,9 +928,9 @@
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "dev": true,
             "requires": {
-                "file-type": "5.2.0",
-                "is-stream": "1.1.0",
-                "tar-stream": "1.6.2"
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0",
+                "tar-stream": "^1.5.2"
             },
             "dependencies": {
                 "file-type": {
@@ -947,11 +947,11 @@
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "dev": true,
             "requires": {
-                "decompress-tar": "4.1.1",
-                "file-type": "6.2.0",
-                "is-stream": "1.1.0",
-                "seek-bzip": "1.0.5",
-                "unbzip2-stream": "1.3.1"
+                "decompress-tar": "^4.1.0",
+                "file-type": "^6.1.0",
+                "is-stream": "^1.1.0",
+                "seek-bzip": "^1.0.5",
+                "unbzip2-stream": "^1.0.9"
             },
             "dependencies": {
                 "file-type": {
@@ -968,9 +968,9 @@
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "dev": true,
             "requires": {
-                "decompress-tar": "4.1.1",
-                "file-type": "5.2.0",
-                "is-stream": "1.1.0"
+                "decompress-tar": "^4.1.1",
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0"
             },
             "dependencies": {
                 "file-type": {
@@ -987,10 +987,10 @@
             "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
             "dev": true,
             "requires": {
-                "file-type": "3.9.0",
-                "get-stream": "2.3.1",
-                "pify": "2.3.0",
-                "yauzl": "2.10.0"
+                "file-type": "^3.8.0",
+                "get-stream": "^2.2.0",
+                "pify": "^2.3.0",
+                "yauzl": "^2.4.2"
             },
             "dependencies": {
                 "file-type": {
@@ -1007,7 +1007,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "defaults": {
@@ -1016,7 +1016,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4"
+                "clone": "^1.0.2"
             }
         },
         "define-properties": {
@@ -1025,7 +1025,7 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "object-keys": "1.0.12"
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1034,8 +1034,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -1044,7 +1044,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1053,7 +1053,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1062,9 +1062,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -1097,7 +1097,7 @@
             "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
             "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
             "requires": {
-                "semver": "5.6.0"
+                "semver": "^5.3.0"
             }
         },
         "diagnostic-channel-publishers": {
@@ -1106,9 +1106,9 @@
             "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
         },
         "diff": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
         "dom-serializer": {
@@ -1117,8 +1117,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.2"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1141,7 +1141,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.2.1"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -1150,8 +1150,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.2.1"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "duplexer": {
@@ -1165,7 +1165,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -1180,10 +1180,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1200,10 +1200,10 @@
             "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -1211,8 +1211,8 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ecdsa-sig-formatter": {
@@ -1220,7 +1220,7 @@
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
             "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "end-of-stream": {
@@ -1228,7 +1228,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "entities": {
@@ -1261,13 +1261,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -1276,13 +1276,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1291,7 +1291,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -1300,7 +1300,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1311,7 +1311,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             },
             "dependencies": {
                 "fill-range": {
@@ -1320,11 +1320,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "3.1.1",
-                        "repeat-element": "1.1.3",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^3.0.0",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "is-number": {
@@ -1333,7 +1333,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -1351,7 +1351,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1362,7 +1362,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "extend": {
@@ -1376,8 +1376,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1386,7 +1386,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1397,14 +1397,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1413,7 +1413,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -1422,7 +1422,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1431,7 +1431,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1440,7 +1440,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1449,9 +1449,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -1467,9 +1467,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -1488,7 +1488,7 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "file-type": {
@@ -1509,10 +1509,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1521,7 +1521,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1538,10 +1538,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.10",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             }
         },
         "fined": {
@@ -1550,11 +1550,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -1575,8 +1575,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "for-in": {
@@ -1591,7 +1591,7 @@
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -1604,9 +1604,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.7",
-                "mime-types": "2.1.21"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -1615,7 +1615,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from": {
@@ -1634,9 +1634,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
             "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
             "requires": {
-                "graceful-fs": "4.1.15",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-mkdirp-stream": {
@@ -1645,8 +1645,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.15",
-                "through2": "2.0.5"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -1660,10 +1660,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.15",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -1678,7 +1678,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "0.1.0"
+                "globule": "~0.1.0"
             }
         },
         "get-stream": {
@@ -1687,8 +1687,8 @@
             "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "pinkie-promise": "2.0.1"
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -1710,7 +1710,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -1718,12 +1718,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -1732,8 +1732,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -1742,7 +1742,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -1757,7 +1757,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -1768,8 +1768,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -1778,12 +1778,12 @@
             "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
             "dev": true,
             "requires": {
-                "glob": "4.5.3",
-                "glob2base": "0.0.12",
-                "minimatch": "2.0.10",
-                "ordered-read-streams": "0.1.0",
-                "through2": "0.6.5",
-                "unique-stream": "1.0.0"
+                "glob": "^4.3.1",
+                "glob2base": "^0.0.12",
+                "minimatch": "^2.0.1",
+                "ordered-read-streams": "^0.1.0",
+                "through2": "^0.6.1",
+                "unique-stream": "^1.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -1792,10 +1792,10 @@
                     "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "2.0.10",
-                        "once": "1.4.0"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^2.0.1",
+                        "once": "^1.3.0"
                     }
                 },
                 "isarray": {
@@ -1810,7 +1810,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.0.0"
                     }
                 },
                 "readable-stream": {
@@ -1819,10 +1819,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1837,8 +1837,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -1849,7 +1849,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "0.5.2"
+                "gaze": "^0.5.1"
             }
         },
         "glob2base": {
@@ -1858,7 +1858,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "0.1.1"
+                "find-index": "^0.1.1"
             }
         },
         "global-modules": {
@@ -1867,9 +1867,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
@@ -1878,11 +1878,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.1"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globule": {
@@ -1891,9 +1891,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "3.1.21",
-                "lodash": "1.0.2",
-                "minimatch": "0.2.14"
+                "glob": "~3.1.21",
+                "lodash": "~1.0.1",
+                "minimatch": "~0.2.11"
             },
             "dependencies": {
                 "glob": {
@@ -1902,9 +1902,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "1.2.3",
-                        "inherits": "1.0.2",
-                        "minimatch": "0.2.14"
+                        "graceful-fs": "~1.2.0",
+                        "inherits": "1",
+                        "minimatch": "~0.2.11"
                     }
                 },
                 "graceful-fs": {
@@ -1931,8 +1931,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -1943,7 +1943,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -1958,9 +1958,9 @@
             "dev": true
         },
         "growl": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
         },
         "gulp": {
@@ -1969,19 +1969,19 @@
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "chalk": "1.1.3",
-                "deprecated": "0.0.1",
-                "gulp-util": "3.0.8",
-                "interpret": "1.1.0",
-                "liftoff": "2.5.0",
-                "minimist": "1.2.0",
-                "orchestrator": "0.3.8",
-                "pretty-hrtime": "1.0.3",
-                "semver": "4.3.6",
-                "tildify": "1.2.0",
-                "v8flags": "2.1.1",
-                "vinyl-fs": "0.3.14"
+                "archy": "^1.0.0",
+                "chalk": "^1.0.0",
+                "deprecated": "^0.0.1",
+                "gulp-util": "^3.0.0",
+                "interpret": "^1.0.0",
+                "liftoff": "^2.1.0",
+                "minimist": "^1.1.0",
+                "orchestrator": "^0.3.0",
+                "pretty-hrtime": "^1.0.0",
+                "semver": "^4.1.0",
+                "tildify": "^1.0.0",
+                "v8flags": "^2.0.2",
+                "vinyl-fs": "^0.3.0"
             },
             "dependencies": {
                 "minimist": {
@@ -2004,9 +2004,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.5"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-decompress": {
@@ -2015,11 +2015,11 @@
             "integrity": "sha512-S0ORQYTqksiKMWClGJtjtIgevrTVUbu7KguP74xxXvIiEINS4v7QjjZ8su8hGYPOJ2zW0WGVysgoct4HzINNqQ==",
             "dev": true,
             "requires": {
-                "archive-type": "4.0.0",
-                "decompress": "4.2.0",
-                "plugin-error": "1.0.1",
-                "readable-stream": "2.3.6",
-                "vinyl": "2.2.0"
+                "archive-type": "^4.0.0",
+                "decompress": "^4.0.0",
+                "plugin-error": "^1.0.1",
+                "readable-stream": "^2.0.2",
+                "vinyl": "^2.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -2046,12 +2046,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -2062,10 +2062,10 @@
             "integrity": "sha1-VKMBj8YZs0HM9kkWBvet8L08c5c=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "request": "2.88.0",
-                "request-progress": "3.0.0",
-                "through": "2.3.8"
+                "gulp-util": "^3.0.8",
+                "request": "^2.88.0",
+                "request-progress": "^3.0.0",
+                "through": "^2.3.8"
             },
             "dependencies": {
                 "gulp-util": {
@@ -2074,24 +2074,24 @@
                     "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
                     "dev": true,
                     "requires": {
-                        "array-differ": "1.0.0",
-                        "array-uniq": "1.0.3",
-                        "beeper": "1.1.1",
-                        "chalk": "1.1.3",
-                        "dateformat": "2.2.0",
-                        "fancy-log": "1.3.2",
-                        "gulplog": "1.0.0",
-                        "has-gulplog": "0.1.0",
-                        "lodash._reescape": "3.0.0",
-                        "lodash._reevaluate": "3.0.0",
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.template": "3.6.2",
-                        "minimist": "1.2.0",
-                        "multipipe": "0.1.2",
-                        "object-assign": "3.0.0",
+                        "array-differ": "^1.0.0",
+                        "array-uniq": "^1.0.2",
+                        "beeper": "^1.0.0",
+                        "chalk": "^1.0.0",
+                        "dateformat": "^2.0.0",
+                        "fancy-log": "^1.1.0",
+                        "gulplog": "^1.0.0",
+                        "has-gulplog": "^0.1.0",
+                        "lodash._reescape": "^3.0.0",
+                        "lodash._reevaluate": "^3.0.0",
+                        "lodash._reinterpolate": "^3.0.0",
+                        "lodash.template": "^3.0.0",
+                        "minimist": "^1.1.0",
+                        "multipipe": "^0.1.2",
+                        "object-assign": "^3.0.0",
                         "replace-ext": "0.0.1",
-                        "through2": "2.0.5",
-                        "vinyl": "0.5.3"
+                        "through2": "^2.0.0",
+                        "vinyl": "^0.5.0"
                     }
                 },
                 "minimist": {
@@ -2106,26 +2106,26 @@
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.7",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.3",
-                        "har-validator": "5.1.3",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.21",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "through": {
@@ -2142,9 +2142,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2153,8 +2153,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -2175,7 +2175,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "kind-of": {
@@ -2190,11 +2190,11 @@
                     "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
                     "dev": true,
                     "requires": {
-                        "ansi-cyan": "0.1.1",
-                        "ansi-red": "0.1.1",
-                        "arr-diff": "1.1.0",
-                        "arr-union": "2.1.0",
-                        "extend-shallow": "1.1.4"
+                        "ansi-cyan": "^0.1.1",
+                        "ansi-red": "^0.1.1",
+                        "arr-diff": "^1.0.1",
+                        "arr-union": "^2.0.1",
+                        "extend-shallow": "^1.1.2"
                     }
                 }
             }
@@ -2205,8 +2205,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -2227,10 +2227,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -2245,8 +2245,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -2255,8 +2255,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -2268,10 +2268,10 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "node.extend": "1.1.8",
-                "request": "2.88.0",
-                "through2": "2.0.5",
-                "vinyl": "2.2.0"
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -2298,12 +2298,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -2314,11 +2314,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.6.0",
-                "graceful-fs": "4.1.15",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.5",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -2327,7 +2327,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "vinyl": {
@@ -2336,8 +2336,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2350,9 +2350,9 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2361,7 +2361,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -2376,9 +2376,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.3"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "expand-brackets": {
@@ -2387,7 +2387,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -2396,7 +2396,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -2405,11 +2405,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -2418,14 +2418,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.2",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -2434,10 +2434,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -2446,8 +2446,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -2464,7 +2464,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -2479,7 +2479,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "micromatch": {
@@ -2488,19 +2488,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "object-assign": {
@@ -2515,8 +2515,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.6"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2531,7 +2531,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "unique-stream": {
@@ -2540,8 +2540,8 @@
                     "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
                     "dev": true,
                     "requires": {
-                        "json-stable-stringify": "1.0.1",
-                        "through2-filter": "2.0.0"
+                        "json-stable-stringify": "^1.0.0",
+                        "through2-filter": "^2.0.0"
                     }
                 },
                 "vinyl": {
@@ -2550,8 +2550,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -2561,23 +2561,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.6.1",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.15",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.6",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.5",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -2588,11 +2588,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.5",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -2601,8 +2601,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2614,24 +2614,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.5",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "minimist": {
@@ -2649,12 +2649,12 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "queue": "4.5.1",
-                "through2": "2.0.5",
-                "vinyl": "2.2.0",
-                "vinyl-fs": "3.0.3",
-                "yauzl": "2.10.0",
-                "yazl": "2.5.0"
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^3.0.3",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -2675,16 +2675,16 @@
                     "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.2",
-                        "glob": "7.1.3",
-                        "glob-parent": "3.1.0",
-                        "is-negated-glob": "1.0.0",
-                        "ordered-read-streams": "1.0.1",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-trailing-separator": "1.1.0",
-                        "to-absolute-glob": "2.0.2",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^7.1.1",
+                        "glob-parent": "^3.1.0",
+                        "is-negated-glob": "^1.0.0",
+                        "ordered-read-streams": "^1.0.0",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.1.5",
+                        "remove-trailing-separator": "^1.0.1",
+                        "to-absolute-glob": "^2.0.0",
+                        "unique-stream": "^2.0.2"
                     }
                 },
                 "is-valid-glob": {
@@ -2699,7 +2699,7 @@
                     "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.6"
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "queue": {
@@ -2708,7 +2708,7 @@
                     "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "replace-ext": {
@@ -2723,8 +2723,8 @@
                     "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
                     "dev": true,
                     "requires": {
-                        "is-absolute": "1.0.0",
-                        "is-negated-glob": "1.0.0"
+                        "is-absolute": "^1.0.0",
+                        "is-negated-glob": "^1.0.0"
                     }
                 },
                 "unique-stream": {
@@ -2733,8 +2733,8 @@
                     "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
                     "dev": true,
                     "requires": {
-                        "json-stable-stringify": "1.0.1",
-                        "through2-filter": "2.0.0"
+                        "json-stable-stringify": "^1.0.0",
+                        "through2-filter": "^2.0.0"
                     }
                 },
                 "vinyl": {
@@ -2743,12 +2743,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 },
                 "vinyl-fs": {
@@ -2757,23 +2757,23 @@
                     "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
                     "dev": true,
                     "requires": {
-                        "fs-mkdirp-stream": "1.0.0",
-                        "glob-stream": "6.1.0",
-                        "graceful-fs": "4.1.15",
-                        "is-valid-glob": "1.0.0",
-                        "lazystream": "1.0.0",
-                        "lead": "1.0.0",
-                        "object.assign": "4.1.0",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-bom-buffer": "3.0.0",
-                        "remove-bom-stream": "1.2.0",
-                        "resolve-options": "1.1.0",
-                        "through2": "2.0.5",
-                        "to-through": "2.0.0",
-                        "value-or-function": "3.0.0",
-                        "vinyl": "2.2.0",
-                        "vinyl-sourcemap": "1.1.0"
+                        "fs-mkdirp-stream": "^1.0.0",
+                        "glob-stream": "^6.1.0",
+                        "graceful-fs": "^4.0.0",
+                        "is-valid-glob": "^1.0.0",
+                        "lazystream": "^1.0.0",
+                        "lead": "^1.0.0",
+                        "object.assign": "^4.0.4",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.3.3",
+                        "remove-bom-buffer": "^3.0.0",
+                        "remove-bom-stream": "^1.2.0",
+                        "resolve-options": "^1.1.0",
+                        "through2": "^2.0.0",
+                        "to-through": "^2.0.0",
+                        "value-or-function": "^3.0.0",
+                        "vinyl": "^2.0.0",
+                        "vinyl-sourcemap": "^1.1.0"
                     }
                 }
             }
@@ -2784,7 +2784,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "har-schema": {
@@ -2797,8 +2797,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "6.5.5",
-                "har-schema": "2.0.0"
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -2807,7 +2807,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -2816,7 +2816,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -2831,7 +2831,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbols": {
@@ -2846,9 +2846,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -2857,8 +2857,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2867,7 +2867,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2877,8 +2877,8 @@
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "he": {
@@ -2893,7 +2893,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "htmlparser2": {
@@ -2902,12 +2902,12 @@
             "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.2",
-                "domutils": "1.5.1",
-                "entities": "1.1.2",
-                "inherits": "2.0.3",
-                "readable-stream": "3.0.6"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.0.6"
             },
             "dependencies": {
                 "domelementtype": {
@@ -2922,9 +2922,9 @@
                     "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 }
             }
@@ -2934,9 +2934,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.15.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "ieee754": {
@@ -2949,8 +2949,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -2982,8 +2982,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -2992,7 +2992,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3001,7 +3001,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3017,7 +3017,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3026,7 +3026,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3037,9 +3037,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3062,7 +3062,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -3083,7 +3083,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-natural-number": {
@@ -3104,7 +3104,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3113,7 +3113,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3130,7 +3130,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -3151,7 +3151,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-stream": {
@@ -3170,7 +3170,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -3218,30 +3218,6 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
-        "jade": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-            "dev": true,
-            "requires": {
-                "commander": "0.6.1",
-                "mkdirp": "0.3.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "0.6.1",
-                    "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.3.0",
-                    "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-                    "dev": true
-                }
-            }
-        },
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3254,8 +3230,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -3268,7 +3244,7 @@
             "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
             "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
             "requires": {
-                "jsonparse": "1.2.0"
+                "jsonparse": "~1.2.0"
             }
         },
         "json-schema": {
@@ -3287,7 +3263,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -3300,7 +3276,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.15"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -3332,7 +3308,7 @@
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.10",
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "jws": {
@@ -3340,8 +3316,8 @@
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
             "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
             "requires": {
-                "jwa": "1.1.6",
-                "safe-buffer": "5.1.2"
+                "jwa": "^1.1.5",
+                "safe-buffer": "^5.0.1"
             }
         },
         "kind-of": {
@@ -3355,7 +3331,7 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lead": {
@@ -3364,7 +3340,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.3"
+                "flush-write-stream": "^1.0.2"
             }
         },
         "liftoff": {
@@ -3373,14 +3349,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.2",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.8.1"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "linkify-it": {
@@ -3389,7 +3365,7 @@
             "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
             "dev": true,
             "requires": {
-                "uc.micro": "1.0.5"
+                "uc.micro": "^1.0.1"
             }
         },
         "lodash": {
@@ -3457,7 +3433,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -3484,9 +3460,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -3501,15 +3477,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -3518,8 +3494,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "lru-cache": {
@@ -3534,7 +3510,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -3551,7 +3527,7 @@
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             }
         },
         "map-cache": {
@@ -3572,7 +3548,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-it": {
@@ -3581,11 +3557,11 @@
             "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "entities": "1.1.2",
-                "linkify-it": "2.1.0",
-                "mdurl": "1.0.1",
-                "uc.micro": "1.0.5"
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
             }
         },
         "math-random": {
@@ -3600,9 +3576,9 @@
             "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
             "dev": true,
             "requires": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "1.1.6"
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
             }
         },
         "md5.js": {
@@ -3610,8 +3586,8 @@
             "resolved": "http://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "mdurl": {
@@ -3626,7 +3602,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -3635,19 +3611,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.13",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             }
         },
         "mime": {
@@ -3666,7 +3642,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
             "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "requires": {
-                "mime-db": "1.37.0"
+                "mime-db": "~1.37.0"
             }
         },
         "minimatch": {
@@ -3674,7 +3650,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -3688,8 +3664,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3698,7 +3674,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -3712,75 +3688,67 @@
             }
         },
         "mocha": {
-            "version": "2.5.3",
-            "resolved": "http://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-            "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
             "dev": true,
             "requires": {
-                "commander": "2.3.0",
-                "debug": "2.2.0",
-                "diff": "1.4.0",
-                "escape-string-regexp": "1.0.2",
-                "glob": "3.2.11",
-                "growl": "1.9.2",
-                "jade": "0.26.3",
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
-                "supports-color": "1.2.0",
-                "to-iso-string": "0.0.2"
+                "supports-color": "5.4.0"
             },
             "dependencies": {
+                "browser-stdout": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+                    "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+                    "dev": true
+                },
                 "commander": {
-                    "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-                    "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+                    "version": "2.15.1",
+                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
                     "dev": true
                 },
                 "debug": {
-                    "version": "2.2.0",
-                    "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "dev": true,
                     "requires": {
-                        "ms": "0.7.1"
+                        "ms": "2.0.0"
                     }
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-                    "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
-                    "dev": true
                 },
                 "glob": {
-                    "version": "3.2.11",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "minimatch": "0.3.0"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
-                },
-                "minimatch": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
-                    }
-                },
-                "ms": {
-                    "version": "0.7.1",
-                    "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                    "dev": true
                 },
                 "supports-color": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-                    "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-                    "dev": true
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
@@ -3790,11 +3758,11 @@
             "integrity": "sha512-y3XuqKa2+HRYtg0wYyhW/XsLm2Ps+pqf9HaTAt7+MVUAKFJaNAHOrNseTZo9KCxjfIbxUWwckP5qCDDPUmjSWA==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "md5": "2.2.1",
-                "mkdirp": "0.5.1",
-                "strip-ansi": "4.0.0",
-                "xml": "1.0.1"
+                "debug": "^2.2.0",
+                "md5": "^2.1.0",
+                "mkdirp": "~0.5.1",
+                "strip-ansi": "^4.0.0",
+                "xml": "^1.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -3809,7 +3777,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -3829,14 +3797,14 @@
             "resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.3.8.tgz",
             "integrity": "sha512-8kaerSPk0Z9W6z8VnJXjKOHDaGGXbsGyO22X4DFtlllzbYLryWo0Dor+jnIKpgvUOzQKSoLW2fel81piG3LnHQ==",
             "requires": {
-                "duplexer": "0.1.1",
-                "is-buffer": "1.1.6",
-                "is-stream": "1.1.0",
-                "moment": "2.22.2",
-                "request": "2.88.0",
-                "through": "2.3.8",
+                "duplexer": "^0.1.1",
+                "is-buffer": "^1.1.6",
+                "is-stream": "^1.1.0",
+                "moment": "^2.21.0",
+                "request": "^2.88.0",
+                "through": "^2.3.8",
                 "tunnel": "0.0.5",
-                "uuid": "3.3.2"
+                "uuid": "^3.2.1"
             }
         },
         "ms-rest-azure": {
@@ -3844,12 +3812,12 @@
             "resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.9.tgz",
             "integrity": "sha512-qonobzWLS7Jl6qwgTuA/SfyCtnv7olvCRKrcF8nzXSj68ds4Oj3K64ntzgQajroKa0hKVMcPUFbTk1IYMGvu8w==",
             "requires": {
-                "adal-node": "0.1.28",
+                "adal-node": "^0.1.28",
                 "async": "2.6.0",
-                "moment": "2.22.2",
-                "ms-rest": "2.3.8",
-                "request": "2.88.0",
-                "uuid": "3.3.2"
+                "moment": "^2.22.2",
+                "ms-rest": "^2.3.2",
+                "request": "^2.88.0",
+                "uuid": "^3.2.1"
             }
         },
         "multimatch": {
@@ -3858,10 +3826,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -3890,17 +3858,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             }
         },
         "natives": {
@@ -3915,8 +3883,8 @@
             "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "has": "1.0.3",
-                "is": "3.2.1"
+                "has": "^1.0.3",
+                "is": "^3.2.1"
             }
         },
         "normalize-path": {
@@ -3924,7 +3892,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "now-and-later": {
@@ -3933,7 +3901,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "nth-check": {
@@ -3942,7 +3910,7 @@
             "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "oauth-sign": {
@@ -3962,9 +3930,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -3973,7 +3941,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "kind-of": {
@@ -3982,7 +3950,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3999,7 +3967,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -4008,10 +3976,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.12"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4020,10 +3988,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "object.map": {
@@ -4032,8 +4000,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.omit": {
@@ -4042,8 +4010,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             },
             "dependencies": {
                 "for-own": {
@@ -4052,7 +4020,7 @@
                     "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -4063,7 +4031,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "once": {
@@ -4071,7 +4039,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "opn": {
@@ -4079,7 +4047,7 @@
             "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
             "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
             "requires": {
-                "is-wsl": "1.1.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "orchestrator": {
@@ -4088,9 +4056,9 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "0.1.5",
-                "sequencify": "0.0.7",
-                "stream-consume": "0.1.1"
+                "end-of-stream": "~0.1.5",
+                "sequencify": "~0.0.7",
+                "stream-consume": "~0.1.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -4099,7 +4067,7 @@
                     "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
                     "dev": true,
                     "requires": {
-                        "once": "1.3.3"
+                        "once": "~1.3.0"
                     }
                 },
                 "once": {
@@ -4108,7 +4076,7 @@
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -4137,8 +4105,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "parse-filepath": {
@@ -4147,9 +4115,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -4158,10 +4126,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -4176,7 +4144,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -4193,7 +4161,7 @@
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
-                "semver": "5.6.0"
+                "semver": "^5.1.0"
             }
         },
         "parse5": {
@@ -4202,7 +4170,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.10.38"
+                "@types/node": "*"
             }
         },
         "pascalcase": {
@@ -4234,7 +4202,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -4249,7 +4217,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -4281,7 +4249,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -4290,10 +4258,10 @@
             "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
             "dev": true,
             "requires": {
-                "ansi-colors": "1.1.0",
-                "arr-diff": "4.0.0",
-                "arr-union": "3.1.0",
-                "extend-shallow": "3.0.2"
+                "ansi-colors": "^1.0.1",
+                "arr-diff": "^4.0.0",
+                "arr-union": "^3.1.0",
+                "extend-shallow": "^3.0.2"
             }
         },
         "portfinder": {
@@ -4301,9 +4269,9 @@
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
             "integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
             "requires": {
-                "async": "1.5.2",
-                "debug": "2.6.9",
-                "mkdirp": "0.5.1"
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
             },
             "dependencies": {
                 "async": {
@@ -4347,8 +4315,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -4357,9 +4325,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.1",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -4390,7 +4358,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -4399,9 +4367,9 @@
             "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -4418,7 +4386,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "readable-stream": {
@@ -4426,13 +4394,13 @@
             "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "rechoir": {
@@ -4441,7 +4409,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.8.1"
+                "resolve": "^1.1.6"
             }
         },
         "regex-cache": {
@@ -4450,7 +4418,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -4459,8 +4427,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "remove-bom-buffer": {
@@ -4469,8 +4437,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -4479,9 +4447,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.2",
-                "through2": "2.0.5"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -4512,26 +4480,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.7",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.3",
-                "har-validator": "5.1.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.21",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             }
         },
         "request-progress": {
@@ -4540,7 +4508,7 @@
             "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
             "dev": true,
             "requires": {
-                "throttleit": "1.0.0"
+                "throttleit": "^1.0.0"
             }
         },
         "request-promise": {
@@ -4548,10 +4516,10 @@
             "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
             "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
             "requires": {
-                "bluebird": "3.5.3",
+                "bluebird": "^3.5.0",
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.4.3"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
             }
         },
         "request-promise-core": {
@@ -4559,7 +4527,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.13.1"
             }
         },
         "requires-port": {
@@ -4574,7 +4542,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -4583,8 +4551,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-options": {
@@ -4593,7 +4561,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -4614,7 +4582,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -4628,7 +4596,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -4647,7 +4615,7 @@
             "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
             "dev": true,
             "requires": {
-                "commander": "2.8.1"
+                "commander": "~2.8.1"
             }
         },
         "semver": {
@@ -4667,10 +4635,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4679,7 +4647,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -4695,7 +4663,7 @@
             "resolved": "http://registry.npmjs.org/simple-git/-/simple-git-1.92.0.tgz",
             "integrity": "sha1-YGFGjrfRnwFBB4/HQuYkV+kQ9Uc=",
             "requires": {
-                "debug": "3.2.6"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -4703,7 +4671,7 @@
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.1.1"
                     }
                 },
                 "ms": {
@@ -4719,14 +4687,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -4735,7 +4703,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -4744,7 +4712,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -4755,9 +4723,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -4766,7 +4734,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4775,7 +4743,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4784,7 +4752,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4793,9 +4761,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -4806,7 +4774,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4815,7 +4783,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4832,11 +4800,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.2",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -4845,8 +4813,8 @@
             "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -4875,7 +4843,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -4884,7 +4852,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -4898,15 +4866,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
             "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -4921,8 +4889,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -4931,7 +4899,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -4947,7 +4915,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-consume": {
@@ -4968,7 +4936,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -4982,7 +4950,7 @@
             "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -4991,7 +4959,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -5000,8 +4968,8 @@
             "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "is-utf8": "0.2.1"
+                "first-chunk-stream": "^1.0.0",
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -5010,8 +4978,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -5020,7 +4988,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -5031,7 +4999,7 @@
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "dev": true,
             "requires": {
-                "is-natural-number": "4.0.1"
+                "is-natural-number": "^4.0.1"
             }
         },
         "supports-color": {
@@ -5046,9 +5014,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "tar-stream": {
@@ -5056,13 +5024,13 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
             "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "requires": {
-                "bl": "1.2.2",
-                "buffer-alloc": "1.2.0",
-                "end-of-stream": "1.4.1",
-                "fs-constants": "1.0.0",
-                "readable-stream": "2.3.6",
-                "to-buffer": "1.1.1",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.2.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.1",
+                "xtend": "^4.0.0"
             }
         },
         "throttleit": {
@@ -5082,8 +5050,8 @@
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -5092,8 +5060,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.5",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "tildify": {
@@ -5102,7 +5070,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "time-stamp": {
@@ -5117,7 +5085,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-absolute-glob": {
@@ -5126,7 +5094,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5135,7 +5103,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -5145,19 +5113,13 @@
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
             "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
         },
-        "to-iso-string": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-            "dev": true
-        },
         "to-object-path": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5166,7 +5128,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5177,10 +5139,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -5189,8 +5151,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "to-through": {
@@ -5199,7 +5161,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.5"
+                "through2": "^2.0.3"
             }
         },
         "tough-cookie": {
@@ -5207,8 +5169,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "requires": {
-                "psl": "1.1.29",
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -5230,18 +5192,18 @@
             "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.19.0",
-                "diff": "3.5.0",
-                "glob": "7.1.3",
-                "js-yaml": "3.12.0",
-                "minimatch": "3.0.4",
-                "resolve": "1.8.1",
-                "semver": "5.6.0",
-                "tslib": "1.9.3",
-                "tsutils": "2.29.0"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.27.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5250,7 +5212,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.3"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -5259,9 +5221,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "commander": {
@@ -5282,7 +5244,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -5293,7 +5255,7 @@
             "integrity": "sha1-Mo7pwo0HzfeTKTIEyW4v+rkiGZQ=",
             "dev": true,
             "requires": {
-                "tsutils": "1.9.1"
+                "tsutils": "^1.4.0"
             },
             "dependencies": {
                 "tsutils": {
@@ -5310,7 +5272,7 @@
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.8.1"
             }
         },
         "tunnel": {
@@ -5323,7 +5285,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -5360,7 +5322,7 @@
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
             "requires": {
-                "is-typedarray": "1.0.0"
+                "is-typedarray": "^1.0.0"
             }
         },
         "typescript": {
@@ -5381,8 +5343,8 @@
             "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
             "dev": true,
             "requires": {
-                "buffer": "3.6.0",
-                "through": "2.3.8"
+                "buffer": "^3.0.1",
+                "through": "^2.3.6"
             },
             "dependencies": {
                 "base64-js": {
@@ -5398,8 +5360,8 @@
                     "dev": true,
                     "requires": {
                         "base64-js": "0.0.8",
-                        "ieee754": "1.1.12",
-                        "isarray": "1.0.0"
+                        "ieee754": "^1.1.4",
+                        "isarray": "^1.0.0"
                     }
                 }
             }
@@ -5421,10 +5383,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5433,7 +5395,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -5442,10 +5404,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -5467,8 +5429,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -5477,9 +5439,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -5506,7 +5468,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             }
         },
         "urix": {
@@ -5527,8 +5489,8 @@
             "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "dev": true,
             "requires": {
-                "querystringify": "2.1.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "use": {
@@ -5559,7 +5521,7 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
         },
         "vali-date": {
@@ -5584,9 +5546,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -5595,8 +5557,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -5606,14 +5568,14 @@
             "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
             "dev": true,
             "requires": {
-                "defaults": "1.0.3",
-                "glob-stream": "3.1.18",
-                "glob-watcher": "0.0.6",
-                "graceful-fs": "3.0.11",
-                "mkdirp": "0.5.1",
-                "strip-bom": "1.0.0",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "defaults": "^1.0.0",
+                "glob-stream": "^3.1.5",
+                "glob-watcher": "^0.0.6",
+                "graceful-fs": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "strip-bom": "^1.0.0",
+                "through2": "^0.6.1",
+                "vinyl": "^0.4.0"
             },
             "dependencies": {
                 "clone": {
@@ -5628,7 +5590,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "1.1.6"
+                        "natives": "^1.1.0"
                     }
                 },
                 "isarray": {
@@ -5643,10 +5605,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -5661,8 +5623,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -5671,8 +5633,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -5683,8 +5645,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.5",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -5699,8 +5661,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -5711,13 +5673,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.6.0",
-                "graceful-fs": "4.1.15",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.2.0"
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -5744,12 +5706,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -5760,23 +5722,23 @@
             "integrity": "sha512-yo7ctgQPK7hKnez/be3Tj7RG3eZzgkFhx/27y9guwzhMxHfjlU1pusAsFT8wBEZKZlYA5HNJAx8oClw4WDWi+A==",
             "dev": true,
             "requires": {
-                "cheerio": "1.0.0-rc.2",
-                "commander": "2.8.1",
-                "denodeify": "1.2.1",
-                "glob": "7.1.3",
-                "lodash": "4.17.11",
-                "markdown-it": "8.4.2",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "osenv": "0.1.5",
-                "parse-semver": "1.1.1",
-                "read": "1.0.7",
-                "semver": "5.6.0",
+                "cheerio": "^1.0.0-rc.1",
+                "commander": "^2.8.1",
+                "denodeify": "^1.2.1",
+                "glob": "^7.0.6",
+                "lodash": "^4.17.10",
+                "markdown-it": "^8.3.1",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "osenv": "^0.1.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^5.1.0",
                 "tmp": "0.0.29",
-                "url-join": "1.1.0",
+                "url-join": "^1.1.0",
                 "vso-node-api": "6.1.2-preview",
-                "yauzl": "2.10.0",
-                "yazl": "2.5.0"
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
             }
         },
         "vscode": {
@@ -5785,20 +5747,20 @@
             "integrity": "sha512-G/zu7PRAN1yF80wg+l6ebIexDflU3uXXeabacJuLearTIfObKw4JaI8aeHwDEmpnCkc3MkIr3Bclkju2gtEz6A==",
             "dev": true,
             "requires": {
-                "glob": "7.1.3",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.1",
-                "gulp-symdest": "1.1.1",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.2",
-                "mocha": "4.1.0",
-                "request": "2.88.0",
-                "semver": "5.6.0",
-                "source-map-support": "0.5.9",
-                "url-parse": "1.4.4",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.1",
+                "gulp-symdest": "^1.1.1",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.2",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "commander": {
@@ -5858,12 +5820,12 @@
                             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                             "dev": true,
                             "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.4",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         }
                     }
@@ -5874,7 +5836,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -5884,22 +5846,22 @@
             "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.25.4.tgz",
             "integrity": "sha512-/xRsfELr7qhSJRj+5Kv5hkzna5Dcc2BV2uvM38MROHAc//6jq2kBeojbY5S3IsMAJmFljbCsTovssljHMHIWyg==",
             "requires": {
-                "archiver": "2.1.1",
-                "azure-arm-resource": "3.0.0-preview",
-                "azure-arm-storage": "3.2.0",
-                "azure-arm-website": "5.7.0",
-                "azure-storage": "2.10.2",
-                "fs-extra": "4.0.3",
-                "ms-rest": "2.3.8",
-                "ms-rest-azure": "2.5.9",
-                "opn": "5.4.0",
-                "request": "2.88.0",
-                "request-promise": "4.2.2",
-                "simple-git": "1.92.0",
-                "vscode-azureextensionui": "0.19.4",
-                "vscode-azurekudu": "0.1.9",
-                "vscode-nls": "4.0.0",
-                "websocket": "1.0.28"
+                "archiver": "^2.0.3",
+                "azure-arm-resource": "^3.0.0-preview",
+                "azure-arm-storage": "^3.1.0",
+                "azure-arm-website": "^5.3.0",
+                "azure-storage": "^2.10.1",
+                "fs-extra": "^4.0.2",
+                "ms-rest": "^2.2.2",
+                "ms-rest-azure": "^2.4.4",
+                "opn": "^5.1.0",
+                "request": "^2.83.0",
+                "request-promise": "^4.2.2",
+                "simple-git": "~1.92.0",
+                "vscode-azureextensionui": "^0.19.4",
+                "vscode-azurekudu": "^0.1.9",
+                "vscode-nls": "^4.0.0",
+                "websocket": "^1.0.25"
             }
         },
         "vscode-azureextensionui": {
@@ -5907,15 +5869,15 @@
             "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.19.4.tgz",
             "integrity": "sha512-ZC/bixHLM8fTebUuZvCzhwZh2XwSombYLlkSioIY2oNShUbPH4WNTpUFJavhLGnrTmvNRsilX35cJRzRiLwQ0g==",
             "requires": {
-                "azure-arm-resource": "3.0.0-preview",
-                "azure-arm-storage": "3.2.0",
-                "fs-extra": "4.0.3",
-                "ms-rest": "2.3.8",
-                "ms-rest-azure": "2.5.9",
-                "opn": "5.4.0",
-                "semver": "5.6.0",
-                "vscode-extension-telemetry": "0.1.0",
-                "vscode-nls": "4.0.0"
+                "azure-arm-resource": "^3.0.0-preview",
+                "azure-arm-storage": "^3.1.0",
+                "fs-extra": "^4.0.3",
+                "ms-rest": "^2.2.2",
+                "ms-rest-azure": "^2.4.4",
+                "opn": "^5.1.0",
+                "semver": "^5.6.0",
+                "vscode-extension-telemetry": "^0.1.0",
+                "vscode-nls": "^4.0.0"
             }
         },
         "vscode-azurekudu": {
@@ -5923,8 +5885,8 @@
             "resolved": "https://registry.npmjs.org/vscode-azurekudu/-/vscode-azurekudu-0.1.9.tgz",
             "integrity": "sha512-spgV4Bb27FtAVXtm3KNtGRKO1+CkFiPvQZqq4J/C3Wa2jpmM5JIEpyM1m3baSODbTeXSJhrinLxKyycGK2yLFA==",
             "requires": {
-                "moment": "2.22.2",
-                "ms-rest": "2.3.8"
+                "moment": "^2.18.1",
+                "ms-rest": "^2.2.2"
             }
         },
         "vscode-debugadapter": {
@@ -5932,7 +5894,7 @@
             "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.32.1.tgz",
             "integrity": "sha512-D7hpwmh4mPNJXLavginjGYbeIpSJj7L/FhfB4EqEnJH2om8jTvnMq6NvOyuHONn6YzarS/L3oAye7RNro9iviw==",
             "requires": {
-                "mkdirp": "0.5.1",
+                "mkdirp": "^0.5.1",
                 "vscode-debugprotocol": "1.32.0"
             }
         },
@@ -5960,10 +5922,10 @@
             "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
             "dev": true,
             "requires": {
-                "q": "1.5.1",
+                "q": "^1.0.1",
                 "tunnel": "0.0.4",
-                "typed-rest-client": "0.9.0",
-                "underscore": "1.9.1"
+                "typed-rest-client": "^0.9.0",
+                "underscore": "^1.8.3"
             },
             "dependencies": {
                 "tunnel": {
@@ -5979,10 +5941,10 @@
             "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
             "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
             "requires": {
-                "debug": "2.6.9",
-                "nan": "2.11.1",
-                "typedarray-to-buffer": "3.1.5",
-                "yaeti": "0.0.6"
+                "debug": "^2.2.0",
+                "nan": "^2.11.0",
+                "typedarray-to-buffer": "^3.1.5",
+                "yaeti": "^0.0.6"
             }
         },
         "which": {
@@ -5991,7 +5953,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "wrappy": {
@@ -6010,7 +5972,7 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
             "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
             "requires": {
-                "sax": "0.5.8"
+                "sax": "0.5.x"
             }
         },
         "xmlbuilder": {
@@ -6044,8 +6006,8 @@
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.1.0"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
@@ -6054,7 +6016,7 @@
             "integrity": "sha512-rgptqKwX/f1/7bIRF1FHb4HGsP5k11QyxBpDl1etUDfNpTa7CNjDOYNPFnIaEzZ9dRq0c47IEJS+sy+T39JCLw==",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         },
         "zip-stream": {
@@ -6062,10 +6024,10 @@
             "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
             "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
             "requires": {
-                "archiver-utils": "1.3.0",
-                "compress-commons": "1.2.2",
-                "lodash": "4.17.11",
-                "readable-stream": "2.3.6"
+                "archiver-utils": "^1.3.0",
+                "compress-commons": "^1.2.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "zone.js": {

--- a/package.json
+++ b/package.json
@@ -891,7 +891,7 @@
     },
     "devDependencies": {
         "@types/fs-extra": "^4.0.5",
-        "@types/mocha": "^2.2.32",
+        "@types/mocha": "^5.2.5",
         "@types/node": "^8.0.51",
         "@types/request": "^2.0.3",
         "@types/request-promise": "4.1.41",
@@ -899,7 +899,7 @@
         "gulp": "^3.9.1",
         "gulp-decompress": "^2.0.2",
         "gulp-download": "^0.0.1",
-        "mocha": "^2.3.3",
+        "mocha": "^5.2.0",
         "mocha-junit-reporter": "^1.18.0",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",


### PR DESCRIPTION
Changes to package-lock are due to using v6.* of npm instead of v5.*

Also update version of mocha to get rid of growl warning