### PR TITLE
Add a 10 second delay to notify user that a deployment completed

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -17,6 +17,7 @@ import * as constants from '../constants';
 import { SiteTreeItem } from '../explorer/SiteTreeItem';
 import { WebAppTreeItem } from '../explorer/WebAppTreeItem';
 import { ext } from '../extensionVariables';
+import { delay } from '../util';
 import * as javaUtil from '../utils/javaUtils';
 import { isPathEqual, isSubpath } from '../utils/pathUtils';
 import * as workspaceUtil from '../utils/workspace';
@@ -163,6 +164,9 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
     const browseWebsite: MessageItem = { title: 'Browse Website' };
     const streamLogs: MessageItem = { title: 'Stream Logs' };
 
+    // referring to this issue https://github.com/Microsoft/vscode-azureappservice/issues/644
+    // waiting 10 seconds is a temporary stop gap and should be changed
+    await delay(10000);
     // Don't wait
     vscode.window.showInformationMessage(deployComplete, browseWebsite, streamLogs, viewOutput).then(async (result: MessageItem | undefined) => {
         if (result === viewOutput) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -78,3 +78,7 @@ export interface IQuickPickItemWithData<T> extends vscode.QuickPickItem {
     persistenceId?: string; // A unique key to identify this item items across sessions, used in persisting previous selections
     data?: T;
 }
+
+export async function delay(delayMs: number): Promise<void> {
+    await new Promise<void>((resolve: () => void): void => { setTimeout(resolve, delayMs); });
+}

--- a/src/validateWebSite.ts
+++ b/src/validateWebSite.ts
@@ -10,6 +10,7 @@ import { URL } from 'url';
 import { isNumber } from 'util';
 import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { SiteTreeItem } from './explorer/SiteTreeItem';
+import { delay } from './util';
 
 const requestPromise = <(options: RequestOptions | string | URL) => Promise<IncomingMessage>><Function>requestP;
 
@@ -100,8 +101,4 @@ export async function validateWebSite(deploymentCorrelationId: string, siteTreeI
             cancellations.delete(id);
         }
     });
-}
-
-async function delay(delayMs: number): Promise<void> {
-    await new Promise<void>((resolve: () => void): void => { setTimeout(resolve, delayMs); });
 }


### PR DESCRIPTION
In reference to this issue: https://github.com/Microsoft/vscode-azureappservice/issues/644

When clicking the `View Website` button, if the user does it immediately after it is displayed, it will unavailable.  Waiting 10 seconds is to try to help mitigate that but is a less than ideal solution.  That being said, my example express app took way longer than 10 seconds to finish building.