### PR TITLE
Remove remote debugging experiment flag + update version check

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -23,3 +23,4 @@ export { constants };
 export * from 'vscode-azureextensionui';
 export { WebAppProvider } from './src/explorer/WebAppProvider';
 export { getRandomHexString } from './src/utils/randomUtils';
+export { checkForRemoteDebugSupport } from './src/commands/remoteDebug/remoteDebugCommon';

--- a/package.json
+++ b/package.json
@@ -367,14 +367,6 @@
                     "when": "never"
                 },
                 {
-                    "command": "appService.StartRemoteDebug",
-                    "when": "never"
-                },
-                {
-                    "command": "appService.DisableRemoteDebug",
-                    "when": "never"
-                },
-                {
                     "command": "appService.ScaleUp",
                     "when": "never"
                 },

--- a/package.json
+++ b/package.json
@@ -368,11 +368,11 @@
                 },
                 {
                     "command": "appService.StartRemoteDebug",
-                    "when": "config.appService.enableRemoteDebugging == true"
+                    "when": "never"
                 },
                 {
                     "command": "appService.DisableRemoteDebug",
-                    "when": "config.appService.enableRemoteDebugging == true"
+                    "when": "never"
                 },
                 {
                     "command": "appService.ScaleUp",
@@ -501,12 +501,12 @@
                 },
                 {
                     "command": "appService.StartRemoteDebug",
-                    "when": "config.appService.enableRemoteDebugging == true && view == azureAppService && viewItem == appService",
+                    "when": "view == azureAppService && viewItem == appService",
                     "group": "5_appServiceRemoteDebugCommands@1"
                 },
                 {
                     "command": "appService.DisableRemoteDebug",
-                    "when": "config.appService.enableRemoteDebugging == true && view == azureAppService && viewItem == appService",
+                    "when": "view == azureAppService && viewItem == appService",
                     "group": "5_appServiceRemoteDebugCommands@2"
                 },
                 {
@@ -586,12 +586,12 @@
                 },
                 {
                     "command": "appService.StartRemoteDebug",
-                    "when": "config.appService.enableRemoteDebugging == true && view == azureAppService && viewItem == deploymentSlot",
+                    "when": "view == azureAppService && viewItem == deploymentSlot",
                     "group": "5_appServiceRemoteDebugCommands@1"
                 },
                 {
                     "command": "appService.DisableRemoteDebug",
-                    "when": "config.appService.enableRemoteDebugging == true && view == azureAppService && viewItem == deploymentSlot",
+                    "when": "view == azureAppService && viewItem == deploymentSlot",
                     "group": "5_appServiceRemoteDebugCommands@2"
                 },
                 {
@@ -821,11 +821,6 @@
                     "scope": "resource",
                     "type": "string",
                     "description": "The default subpath of a workspace folder to use when deploying."
-                },
-                "appService.enableRemoteDebugging": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enables remote debugging of a Web App. This experimental preview only supports node on Linux."
                 },
                 "appService.defaultWebAppToDeploy": {
                     "scope": "resource",

--- a/src/commands/remoteDebug/disableRemoteDebug.ts
+++ b/src/commands/remoteDebug/disableRemoteDebug.ts
@@ -25,10 +25,7 @@ export async function disableRemoteDebug(actionContext: IActionContext, node?: S
         remoteDebug.reportMessage('Fetching site configuration...', progress);
         const siteConfig: SiteConfigResource = await siteClient.getSiteConfig();
 
-        // Add the image version to the telemetry for this action
-        actionContext.properties.linuxFxVersion = siteConfig.linuxFxVersion;
-
-        remoteDebug.checkForRemoteDebugSupport(siteConfig);
+        remoteDebug.checkForRemoteDebugSupport(siteConfig, actionContext);
         await remoteDebug.setRemoteDebug(false, confirmMessage, noopMessage, siteClient, siteConfig, progress);
     });
 }

--- a/src/commands/remoteDebug/remoteDebugCommon.ts
+++ b/src/commands/remoteDebug/remoteDebugCommon.ts
@@ -51,8 +51,8 @@ function isNodeVersionSupported(nodeVersion: string): boolean {
         return false;
     }
 
-    const major = Number(splitNodeVersion[0]) || 0;
-    const minor = Number(splitNodeVersion[1]) || 0;
+    const major = +splitNodeVersion[0];
+    const minor = +splitNodeVersion[1];
 
     return (major > 8 || (major === 8 && minor >= 11));
 }

--- a/src/commands/remoteDebug/startRemoteDebug.ts
+++ b/src/commands/remoteDebug/startRemoteDebug.ts
@@ -39,10 +39,7 @@ async function startRemoteDebugInternal(actionContext: IActionContext, node?: Si
         remoteDebug.reportMessage('Fetching site configuration...', progress);
         const siteConfig: SiteConfigResource = await siteClient.getSiteConfig();
 
-        // Add the image version to the telemetry for this action
-        actionContext.properties.linuxFxVersion = siteConfig.linuxFxVersion;
-
-        remoteDebug.checkForRemoteDebugSupport(siteConfig);
+        remoteDebug.checkForRemoteDebugSupport(siteConfig, actionContext);
         const debugConfig: vscode.DebugConfiguration = await getDebugConfiguration();
         // tslint:disable-next-line:no-unsafe-any
         const portNumber: number = debugConfig.port;

--- a/test/remoteDebug/checkForRemoteDebugSupport.test.ts
+++ b/test/remoteDebug/checkForRemoteDebugSupport.test.ts
@@ -32,6 +32,7 @@ suite('checkForRemoteDebugSupport', () => {
         // bad node versions
         assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'NODE' }, actionContext); }, Error);
         assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'node|9' }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'node|not.number' }, actionContext); }, Error);
         assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'NODE|6.12' }, actionContext); }, Error);
         assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'node|8.10' }, actionContext); }, Error);
     });

--- a/test/remoteDebug/checkForRemoteDebugSupport.test.ts
+++ b/test/remoteDebug/checkForRemoteDebugSupport.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IActionContext } from 'vscode-azureextensionui';
+import { checkForRemoteDebugSupport } from '../../extension.bundle';
+
+suite('checkForRemoteDebugSupport', () => {
+    function getEmptyActionContext(): IActionContext {
+        return {
+            measurements: {},
+            properties: {}
+        };
+    }
+
+    test('Checks bad versions', async () => {
+        const actionContext = getEmptyActionContext();
+
+        // empty version
+        assert.throws(() => { checkForRemoteDebugSupport({}, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: undefined }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: '' }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: ' ' }, actionContext); }, Error);
+
+        // not node
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'php' }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'PYTHON|8.11' }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'docker|image' }, actionContext); }, Error);
+
+        // bad node versions
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'NODE' }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'node|9' }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'NODE|6.12' }, actionContext); }, Error);
+        assert.throws(() => { checkForRemoteDebugSupport({ linuxFxVersion: 'node|8.10' }, actionContext); }, Error);
+    });
+
+    test('Checks good versions', async () => {
+        const actionContext = getEmptyActionContext();
+
+        // >= 8.11 is valid
+        checkForRemoteDebugSupport({ linuxFxVersion: 'node|8.11' }, actionContext);
+        checkForRemoteDebugSupport({ linuxFxVersion: 'NODE|8.12' }, actionContext);
+        checkForRemoteDebugSupport({ linuxFxVersion: 'node|9.0' }, actionContext);
+        checkForRemoteDebugSupport({ linuxFxVersion: 'NODE|10.11' }, actionContext);
+    });
+
+    test('Reports telemetry correctly', async () => {
+        const actionContext = getEmptyActionContext();
+
+        checkForRemoteDebugSupport({ linuxFxVersion: 'NODE|8.11' }, actionContext);
+        assert.equal(actionContext.properties.linuxFxVersion, 'node|8.11');
+
+        // Docker image information should be removed from telemetry
+        try {
+            checkForRemoteDebugSupport({ linuxFxVersion: 'docker|image' }, actionContext);
+        } catch (e) {
+            // ignore error
+        }
+        assert.equal(actionContext.properties.linuxFxVersion, 'docker');
+    });
+});


### PR DESCRIPTION
Fixes #802 and fixes #806 

Remove the remote debugging experiment flag so that the menu items show for all users. At the same time, improve the check for remote debugging support to only allow remote debugging for Node >= 8.11

Error message is:
'Azure Remote Debugging is currently only supported for Node.js version >= 8.11 on Linux.'