### PR TITLE
Don't use webpack for local debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,26 @@
             ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            // outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "preLaunchTask": "npm: compile",
+            "env": {
+                "AZCODE_IGNORE_BUNDLE": "1",
+                "DEBUGTELEMETRY": "1",
+                "NODE_DEBUG": ""
+            }
+        },
+        {
+            "name": "Launch Extension (webpack)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ],
@@ -34,7 +53,6 @@
             ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            // outFiles is used for locating generated JavaScript files, see https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_source-maps
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"
             ],
@@ -44,8 +62,9 @@
                 "MOCHA_enableTimeouts": "0", // Disable time-outs
                 "DEBUGTELEMETRY": "1",
                 "NODE_DEBUG": "",
-                "DEBUG_WEBPACK": ""
+                "DEBUG_WEBPACK": "",
+                "ENABLE_LONG_RUNNING_TESTS": ""
             }
-        },
+        }
     ]
 }

--- a/main.js
+++ b/main.js
@@ -16,7 +16,9 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const extension = require("./dist/extension.bundle");
+const ignoreBundle = !/^(false|0)?$/i.test(process.env.AZCODE_IGNORE_BUNDLE || '');
+const extensionPath = ignoreBundle ? "./out/src/extension" : "./dist/extension.bundle";
+const extension = require(extensionPath);
 
 async function activate(ctx) {
     return await extension.activateInternal(ctx, perfStats);


### PR DESCRIPTION
Same as https://github.com/Microsoft/vscode-azurefunctions/pull/1151

Also note for both repos, icons only work if you launch with webpack haha:
![Screen Shot 2019-04-02 at 11 23 26 AM](https://user-images.githubusercontent.com/11282622/55426503-d1a10b80-5539-11e9-8e3f-9a86fba17006.png)

Do we care about that? Doesn't seem like a blocker for this PR - but might be worth fixing eventually.