### PR TITLE
Update CI configuration

### DIFF
--- a/.azure-pipelines/windows/intellinav.yml
+++ b/.azure-pipelines/windows/intellinav.yml
@@ -6,3 +6,4 @@ steps:
     nugetpat: 'azureappservice-nuget' # name of the NuGet service connection
     language: 'typescript' # languages in your repo, separated by commas
     githubpat: 'GitHub connection' # if your repo is on GitHub, this is the name of the GitHub service connection (GitHub organization by default)
+  continueOnError: true


### PR DESCRIPTION
This change adds `continueOnError: true` to the build task configuration for rich nav, so that the build does not break if the build task fails.