### PR TITLE
Remove await on vscode.showInformationMessage

### DIFF
--- a/src/commands/appSettings/downloadAppSettings.ts
+++ b/src/commands/appSettings/downloadAppSettings.ts
@@ -39,12 +39,13 @@ export async function downloadAppSettings(node?: AppSettingsTreeItem): Promise<v
         await fse.writeFile(envVarPath, convertAppSettingsToEnvVariables(localEnvVariables, client.fullName));
     });
 
-    const input: string | undefined = await window.showInformationMessage(`Downloaded settings from "${client.fullName}".  View settings file?`, 'View file');
-    if (!input) {
-        throw new UserCancelledError();
-    }
-    const doc: vscode.TextDocument = await vscode.workspace.openTextDocument(envVarUri);
-    await vscode.window.showTextDocument(doc);
+    window.showInformationMessage(`Downloaded settings from "${client.fullName}".  View settings file?`, 'View file').then(async (input) => {
+        if (!input) {
+            throw new UserCancelledError();
+        }
+        const doc: vscode.TextDocument = await vscode.workspace.openTextDocument(envVarUri);
+        await vscode.window.showTextDocument(doc);
+    });
 }
 
 export function convertAppSettingsToEnvVariables(appSettings: { [propertyName: string]: string }, appName: string): string {

--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -41,5 +41,7 @@ export async function uploadAppSettings(target?: Uri | AppSettingsTreeItem | und
             throw new Error(`No enviroment variables found in "${envFileName}".`);
         }
     });
-    await window.showInformationMessage(`Uploaded settings to "${client.fullName}".`);
+
+    // tslint:disable-next-line: no-floating-promises
+    window.showInformationMessage(`Uploaded settings to "${client.fullName}".`);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -240,12 +240,14 @@ export async function activateInternal(
             const createdSlot = <SiteTreeItem>await node.createChild(this);
 
             // prompt user to deploy to newly created web app
-            if (await vscode.window.showInformationMessage('Deploy to deployment slot?', yesButton, noButton) === yesButton) {
-                this.properties[deployingToDeploymentSlot] = 'true';
-                await deploy(this, false, createdSlot);
-            } else {
-                this.properties[deployingToDeploymentSlot] = 'false';
-            }
+            vscode.window.showInformationMessage('Deploy to deployment slot?', yesButton, noButton).then(async (input) => {
+                if (input === yesButton) {
+                    this.properties[deployingToDeploymentSlot] = 'true';
+                    await deploy(this, false, createdSlot);
+                } else {
+                    this.properties[deployingToDeploymentSlot] = 'false';
+                }
+            });
         });
         registerCommand('appService.SwapSlots', async (node: DeploymentSlotTreeItem) => await swapSlots(node));
         registerCommand('appService.appSettings.Add', async (node?: AppSettingsTreeItem) => {


### PR DESCRIPTION
`informationMessages` shouldn't require user input to proceed (otherwise use a modal or `warningMessage`).

These messages were preventing automated tests from being written since there isn't a way for our Test UI to interact with `vscode.window.showInformationMessage`