### PR TITLE
Add nonNull util and apply wherever tslint rule applied

### DIFF
--- a/src/commands/connections/addCosmosDBConnection.ts
+++ b/src/commands/connections/addCosmosDBConnection.ts
@@ -6,6 +6,7 @@
 import { AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
 import { CosmosDBTreeItem } from '../../explorer/CosmosDBTreeItem';
 import { ext } from "../../extensionVariables";
+import { nonNullProp } from '../../utils/nonNull';
 
 export async function addCosmosDBConnection(node?: AzureTreeItem): Promise<void> {
     if (!node) {
@@ -16,8 +17,7 @@ export async function addCosmosDBConnection(node?: AzureTreeItem): Promise<void>
     if (node instanceof CosmosDBTreeItem) {
         cosmosDBTreeItem = node;
     } else {
-        // tslint:disable-next-line:no-non-null-assertion
-        cosmosDBTreeItem = node.parent!;
+        cosmosDBTreeItem = nonNullProp(node, 'parent');
     }
     await cosmosDBTreeItem.createChild();
     await ext.tree.refresh(cosmosDBTreeItem);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,6 +18,7 @@ import { WebAppTreeItem } from '../explorer/WebAppTreeItem';
 import { ext } from '../extensionVariables';
 import { showQuickPickByFileExtension } from '../util';
 import { delay } from '../utils/delay';
+import { nonNullValue } from '../utils/nonNull';
 import { isPathEqual, isSubpath } from '../utils/pathUtils';
 import { getRandomHexString } from "../utils/randomUtils";
 import * as workspaceUtil from '../utils/workspace';
@@ -145,8 +146,7 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
         await delay(500);
         const result: vscode.MessageItem = await ext.ui.showWarningMessage(warning, { modal: true }, ...items);
         if (result === resetDefault) {
-            // tslint:disable-next-line:no-non-null-assertion
-            const localRootPath = currentWorkspace!.uri.fsPath;
+            const localRootPath = nonNullValue(currentWorkspace).uri.fsPath;
             const settingsPath = path.join(localRootPath, '.vscode', 'settings.json');
             const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(settingsPath));
             vscode.window.showTextDocument(doc);
@@ -167,8 +167,7 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
 
     cancelWebsiteValidation(node);
     await node.runWithTemporaryDescription("Deploying...", async () => {
-        // tslint:disable-next-line:no-non-null-assertion
-        await appservice.deploy(node!.root.client, <string>fsPath, context);
+        await appservice.deploy(nonNullValue(node).root.client, <string>fsPath, context);
     });
 
     const deployComplete: string = `Deployment to "${node.root.client.fullName}" completed.`;
@@ -182,8 +181,7 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
         if (result === viewOutput) {
             ext.outputChannel.show();
         } else if (result === browseWebsite) {
-            // tslint:disable-next-line:no-non-null-assertion
-            await node!.browse();
+            await nonNullValue(node).browse();
         } else if (result === streamLogs) {
             await startStreamingLogs(node);
         }

--- a/src/commands/enableFileLogging.ts
+++ b/src/commands/enableFileLogging.ts
@@ -14,7 +14,6 @@ export async function enableFileLogging(node: SiteTreeItem): Promise<void> {
     const enabledLogging: string = `Enabled Logging for "${node.root.client.fullName}".`;
     await window.withProgress({ location: ProgressLocation.Notification, title: enablingLogging }, async (): Promise<void> => {
         ext.outputChannel.appendLine(enablingLogging);
-        // tslint:disable-next-line:no-non-null-assertion
         await node.enableHttpLogs();
         await commands.executeCommand('appService.Restart', node);
         window.showInformationMessage(enabledLogging);

--- a/src/explorer/CosmosDBTreeItem.ts
+++ b/src/explorer/CosmosDBTreeItem.ts
@@ -9,6 +9,7 @@ import { ISiteTreeRoot, validateAppSettingKey } from 'vscode-azureappservice';
 import { AzureParentTreeItem, AzureTreeItem, createTreeItemsWithErrorHandling, GenericTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { ext } from '../extensionVariables';
+import { nonNullProp } from '../utils/nonNull';
 import { getThemedIconPath, IThemedIconPath } from '../utils/pathUtils';
 import { CosmosDBExtensionApi, DatabaseTreeItem } from '../vscode-cosmos.api';
 import { ConnectionsTreeItem } from './ConnectionsTreeItem';
@@ -226,10 +227,8 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         });
 
         return new Map([
-            // tslint:disable-next-line:no-non-null-assertion
-            [appSettingPrefix + this._endpointSuffix, database.docDBData!.documentEndpoint],
-            // tslint:disable-next-line:no-non-null-assertion
-            [appSettingPrefix + this._keySuffix, database.docDBData!.masterKey],
+            [appSettingPrefix + this._endpointSuffix, nonNullProp(database, 'docDBData').documentEndpoint],
+            [appSettingPrefix + this._keySuffix, nonNullProp(database, 'docDBData').masterKey],
             [appSettingPrefix + this._databaseSuffix, database.databaseName]
         ]);
     }

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SiteClient } from 'vscode-azureappservice';
+import { nonNullProp } from '../utils/nonNull';
 import { getThemedIconPath, IThemedIconPath } from '../utils/pathUtils';
 import { DeploymentSlotsTreeItem } from './DeploymentSlotsTreeItem';
 import { SiteTreeItem } from './SiteTreeItem';
@@ -18,8 +19,7 @@ export class DeploymentSlotTreeItem extends SiteTreeItem {
     }
 
     public get label(): string {
-        // tslint:disable-next-line:no-non-null-assertion
-        return this.root.client.slotName!;
+        return nonNullProp(this.root.client, 'slotName');
     }
 
     public get iconPath(): IThemedIconPath {

--- a/src/explorer/WebAppTreeItem.ts
+++ b/src/explorer/WebAppTreeItem.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { ISiteTreeRoot } from 'vscode-azureappservice';
 import { AzureTreeItem, createAzureClient } from 'vscode-azureextensionui';
 import { extensionPrefix } from '../constants';
+import { nonNullProp, nonNullValue } from '../utils/nonNull';
 import { getResourcesPath, getThemedIconPath, IThemedIconPath } from '../utils/pathUtils';
 import { DeploymentSlotsNATreeItem, DeploymentSlotsTreeItem } from './DeploymentSlotsTreeItem';
 import { DeploymentSlotTreeItem } from './DeploymentSlotTreeItem';
@@ -40,8 +41,7 @@ export class WebAppTreeItem extends SiteTreeItem {
             tier = 'unknown';
         }
 
-        // tslint:disable-next-line:no-non-null-assertion
-        this.deploymentSlotsNode = tier && /^(basic|free|shared)$/i.test(tier) ? new DeploymentSlotsNATreeItem(this, asp!.id!) : new DeploymentSlotsTreeItem(this);
+        this.deploymentSlotsNode = tier && /^(basic|free|shared)$/i.test(tier) ? new DeploymentSlotsNATreeItem(this, nonNullProp(nonNullValue(asp), 'id')) : new DeploymentSlotsTreeItem(this);
         return (await super.loadMoreChildrenImpl(clearCache)).concat(this.deploymentSlotsNode);
     }
 

--- a/src/explorer/editors/FileEditor.ts
+++ b/src/explorer/editors/FileEditor.ts
@@ -8,6 +8,7 @@ import { Readable } from 'stream';
 import * as vscode from 'vscode';
 import { getFile, IFileResult, putFile } from 'vscode-azureappservice';
 import { BaseEditor } from 'vscode-azureextensionui';
+import { nonNullProp } from '../../utils/nonNull';
 import { FileTreeItem } from '../FileTreeItem';
 
 export class FileEditor extends BaseEditor<FileTreeItem> {
@@ -39,8 +40,7 @@ export class FileEditor extends BaseEditor<FileTreeItem> {
             throw new Error('Cannot update file after it has been closed.');
         }
         const localFile: Readable = fs.createReadStream(vscode.window.activeTextEditor.document.uri.fsPath);
-        // tslint:disable-next-line:no-non-null-assertion
-        node.etag = await putFile(node.root.client, localFile, node.path, node.etag!);
+        node.etag = await putFile(node.root.client, localFile, node.path, nonNullProp(node, 'etag'));
         return await this.getData(node);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,7 @@ import { LogPointsManager } from './logPoints/LogPointsManager';
 import { LogPointsSessionWizard } from './logPoints/LogPointsSessionWizard';
 import { RemoteScriptDocumentProvider, RemoteScriptSchema } from './logPoints/remoteScriptDocumentProvider';
 import { LogpointsCollection } from './logPoints/structs/LogpointsCollection';
+import { nonNullProp, nonNullValue } from './utils/nonNull';
 import { openUrl } from './utils/openUrl';
 
 // tslint:disable-next-line:export-name
@@ -124,8 +125,7 @@ export async function activateInternal(
             switch (node.contextValue) {
                 // the deep link for slots does not follow the conventional pattern of including its parent in the path name so this is how we extract the slot's id
                 case DeploymentSlotsTreeItem.contextValue:
-                    // tslint:disable-next-line:no-non-null-assertion
-                    await node.openInPortal(`${node.parent!.fullId}/deploymentSlots`);
+                    await node.openInPortal(`${nonNullProp(node, 'parent').fullId}/deploymentSlots`);
                     return;
                 // the deep link for "Deployments" do not follow the conventional pattern of including its parent in the path name so we need to pass the "Deployment Center" url directly
                 case DeploymentsTreeItem.contextValueConnected:
@@ -225,8 +225,7 @@ export async function activateInternal(
 
             await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async p => {
                 p.report({ message: 'Generating script...' });
-                // tslint:disable-next-line:no-non-null-assertion
-                await node!.generateDeploymentScript();
+                await nonNullValue(node).generateDeploymentScript();
             });
         });
         registerCommand('appService.CreateSlot', async function (this: IActionContext, node?: DeploymentSlotsTreeItem): Promise<void> {
@@ -327,7 +326,6 @@ export async function activateInternal(
             if (!isEnabled) {
                 await enableFileLogging(<SiteTreeItem>node);
             } else {
-                // tslint:disable-next-line:no-non-null-assertion
                 vscode.window.showInformationMessage(`File logging has already been enabled for ${node.root.client.fullName}.`);
             }
         });

--- a/src/utils/nonNull.ts
+++ b/src/utils/nonNull.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isNullOrUndefined } from 'util';
+
+/**
+ * Retrieves a property by name from an object and checks that it's not null and not undefined.  It is strongly typed
+ * for the property and will give a compile error if the given name is not a property of the source.
+ */
+export function nonNullProp<TSource, TKey extends keyof TSource>(source: TSource, name: TKey): NonNullable<TSource[TKey]> {
+    const value: NonNullable<TSource[TKey]> = <NonNullable<TSource[TKey]>>source[name];
+    return nonNullValue(value, <string>name);
+}
+
+/**
+ * Validates that a given value is not null and not undefined.
+ */
+export function nonNullValue<T>(value: T | undefined, propertyNameOrMessage?: string): T {
+    if (isNullOrUndefined(value)) {
+        throw new Error(
+            // tslint:disable-next-line:prefer-template
+            'Internal error: Expected value to be neither null nor undefined'
+            + (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''));
+    }
+
+    return value;
+}
+
+/**
+ * Validates that a given string is not null, undefined, nor empty
+ */
+export function nonNullOrEmptyValue(value: string | undefined, propertyNameOrMessage?: string): string {
+    if (!value) {
+        throw new Error(
+            // tslint:disable-next-line:prefer-template
+            'Internal error: Expected value to be neither null, undefined, nor empty'
+            + (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''));
+    }
+
+    return value;
+}


### PR DESCRIPTION
There were several references to non-null values in the logpoints files.   I wasn't sure whether or not I should be calling `nonNullProp` on these values.

Fixes https://github.com/microsoft/vscode-azureappservice/issues/980