### PR TITLE
Default all apps in basic creation to F1 tier

### DIFF
--- a/.azure-pipelines/windows/intellinav.yml
+++ b/.azure-pipelines/windows/intellinav.yml
@@ -1,10 +1,7 @@
 steps:
-- task: vsintellinav.vsck-service-endpoint.build-task.upload-cache-build-task@0
-  displayName: 'VS IntelliNav Upload'
+- task: RichCodeNavIndexer@0
   inputs:
     serviceConnection: 'azuretools-dev' # name of the IntelliNav service connection
-    nugetServiceConnection: 'azuretools-nuget' # name of the NuGet service connection
     languages: 'typescript' # languages in your repo, separated by commas
     githubServiceConnection: 'GitHub connection' # if your repo is on GitHub, this is the name of the GitHub service connection (GitHub organization by default)
-    serviceEndpoint: 'https://prod.richnav.vsengsaas.visualstudio.com'
   continueOnError: true

--- a/src/explorer/setAppWizardContextDefault.ts
+++ b/src/explorer/setAppWizardContextDefault.ts
@@ -45,21 +45,18 @@ export async function setAppWizardContextDefault(wizardContext: IAppServiceWizar
             await LocationListStep.setLocation(wizardContext, 'centralus');
         }
 
+        if (!wizardContext.newPlanSku) {
+            // don't overwrite the planSku if it is already set
+            wizardContext.newPlanSku = { name: 'F1', tier: 'Free', size: 'F1', family: 'F', capacity: 1 };
+        }
+
         // if we are recommending a runtime, then it is either Nodejs, Python, or Java which all use Linux
         if (wizardContext.recommendedSiteRuntime) {
             wizardContext.newSiteOS = WebsiteOS.linux;
-            if (!wizardContext.newPlanSku) {
-                // don't overwrite the planSku if it is already set
-                wizardContext.newPlanSku = { name: 'B1', tier: 'Basic', size: 'B1', family: 'B', capacity: 1 };
-            }
         } else {
             await workspace.findFiles('*.csproj').then((files: Uri[]) => {
                 if (files.length > 0) {
                     wizardContext.newSiteOS = WebsiteOS.windows;
-                    if (!wizardContext.newPlanSku) {
-                        // don't overwrite the planSku if it is already set
-                        wizardContext.newPlanSku = { name: 'F1', tier: 'Free', size: 'F1', family: 'F', capacity: 1 };
-                    }
                 }
             });
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/992
Related https://github.com/microsoft/vscode-azuretools/pull/506

Even though the azuretools PR is related, this PR doesn't actually rely on that PR as the basic creation doesn't use the SKU list.  That PR is for enabling users in advanced creation to access the F1 tier for Linux apps.