### PR TITLE
Connect to GitHub fix

### DIFF
--- a/.azure-pipelines/windows/intellinav.yml
+++ b/.azure-pipelines/windows/intellinav.yml
@@ -1,10 +1,7 @@
 steps:
-- task: vsintellinav.vsck-service-endpoint.build-task.upload-cache-build-task@0
-  displayName: 'VS IntelliNav Upload'
+- task: RichCodeNavIndexer@0
   inputs:
     serviceConnection: 'azuretools-dev' # name of the IntelliNav service connection
-    nugetServiceConnection: 'azuretools-nuget' # name of the NuGet service connection
     languages: 'typescript' # languages in your repo, separated by commas
     githubServiceConnection: 'GitHub connection' # if your repo is on GitHub, this is the name of the GitHub service connection (GitHub organization by default)
-    serviceEndpoint: 'https://prod.richnav.vsengsaas.visualstudio.com'
   continueOnError: true

--- a/src/commands/deployments/connectToGitHub.ts
+++ b/src/commands/deployments/connectToGitHub.ts
@@ -4,18 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DeploymentsTreeItem, editScmType } from "vscode-azureappservice";
-import { IActionContext } from "vscode-azureextensionui";
+import { GenericTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ScmType } from "../../constants";
-import { SiteTreeItem } from "../../explorer/SiteTreeItem";
 import { WebAppTreeItem } from "../../explorer/WebAppTreeItem";
 import { ext } from "../../extensionVariables";
 
-export async function connectToGitHub(context: IActionContext, node?: WebAppTreeItem | DeploymentsTreeItem): Promise<void> {
-    if (!node) {
+export async function connectToGitHub(context: IActionContext, target?: GenericTreeItem): Promise<void> {
+    let node: WebAppTreeItem | DeploymentsTreeItem;
+
+    if (!target) {
         node = <WebAppTreeItem>await ext.tree.showTreeItemPicker(WebAppTreeItem.contextValue, context);
+    } else {
+        node = <DeploymentsTreeItem>target.parent;
     }
+
     await editScmType(node.root.client, node, context, ScmType.GitHub);
-    if (node instanceof SiteTreeItem) {
+
+    if (node instanceof WebAppTreeItem) {
         if (node.deploymentsNode) {
             await node.deploymentsNode.refresh();
         }

--- a/src/commands/deployments/connectToGitHub.ts
+++ b/src/commands/deployments/connectToGitHub.ts
@@ -6,6 +6,7 @@
 import { DeploymentsTreeItem, editScmType } from "vscode-azureappservice";
 import { GenericTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ScmType } from "../../constants";
+import { SiteTreeItem } from "../../explorer/SiteTreeItem";
 import { WebAppTreeItem } from "../../explorer/WebAppTreeItem";
 import { ext } from "../../extensionVariables";
 
@@ -20,7 +21,7 @@ export async function connectToGitHub(context: IActionContext, target?: GenericT
 
     await editScmType(node.root.client, node, context, ScmType.GitHub);
 
-    if (node instanceof WebAppTreeItem) {
+    if (node instanceof SiteTreeItem) {
         if (node.deploymentsNode) {
             await node.deploymentsNode.refresh();
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/997

There will only not be a target if entered via context menu.  `Connect to GitHub` is only through the GenericTreeItem with DeploymentsTreeItem as its parent.