### PR TITLE
Checks to see if there was a deploy path to stifle create notification

### DIFF
--- a/src/commands/createWebApp.ts
+++ b/src/commands/createWebApp.ts
@@ -35,5 +35,5 @@ export async function createWebApp(context: IActionContext, node?: AzureParentTr
         throw error;
     }
 
-    newSite.showCreatedOutput(context);
+    newSite.promptToDeploy(context);
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -153,7 +153,7 @@ export async function deploy(context: IDeployWizardContext, confirmDeployment: b
     if (confirmDeployment && siteConfig.scmType !== constants.ScmType.LocalGit && siteConfig !== constants.ScmType.GitHub) {
         const warning: string = `Are you sure you want to deploy to "${node.root.client.fullName}"? This will overwrite any previous deployment and cannot be undone.`;
         context.telemetry.properties.cancelStep = 'confirmDestructiveDeployment';
-        const items: MessageItem[] = [{ title: 'Deploy' }];
+        const items: MessageItem[] = [constants.AppServiceDialogResponses.deploy];
         const resetDefault: MessageItem = { title: 'Reset default' };
         if (defaultWebAppToDeploy) {
             items.push(resetDefault);
@@ -190,13 +190,12 @@ export async function deploy(context: IDeployWizardContext, confirmDeployment: b
 
     const deployComplete: string = `Deployment to "${node.root.client.fullName}" completed.`;
     ext.outputChannel.appendLine(deployComplete);
-    const viewOutput: MessageItem = { title: 'View Output' };
     const browseWebsite: MessageItem = { title: 'Browse Website' };
     const streamLogs: MessageItem = { title: 'Stream Logs' };
 
     // Don't wait
-    window.showInformationMessage(deployComplete, browseWebsite, streamLogs, viewOutput).then(async (result: MessageItem | undefined) => {
-        if (result === viewOutput) {
+    window.showInformationMessage(deployComplete, browseWebsite, streamLogs, constants.AppServiceDialogResponses.viewOutput).then(async (result: MessageItem | undefined) => {
+        if (result === constants.AppServiceDialogResponses.viewOutput) {
             ext.outputChannel.show();
         } else if (result === browseWebsite) {
             await nonNullValue(node).browse();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { MessageItem } from "vscode";
 
 export const deploymentFileName: string = '.deployment';
 export const deploymentFile: string = `[config]
@@ -24,6 +26,11 @@ export enum ScmType {
     None = 'None', // default scmType
     LocalGit = 'LocalGit',
     GitHub = 'GitHub'
+}
+
+export namespace AppServiceDialogResponses {
+    export const deploy: MessageItem = { title: 'Deploy' };
+    export const viewOutput: MessageItem = { title: 'View Output' };
 }
 
 export const envFileName: string = '.env';

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -3,7 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { MessageItem, window } from 'vscode';
 import { SiteClient } from 'vscode-azureappservice';
+import { IActionContext } from 'vscode-azureextensionui';
+import { deploy } from '../commands/deploy';
+import { AppServiceDialogResponses } from '../constants';
+import { ext } from '../extensionVariables';
 import { nonNullProp } from '../utils/nonNull';
 import { getThemedIconPath, IThemedIconPath } from '../utils/pathUtils';
 import { DeploymentSlotsTreeItem } from './DeploymentSlotsTreeItem';
@@ -24,5 +29,18 @@ export class DeploymentSlotTreeItem extends SiteTreeItem {
 
     public get iconPath(): IThemedIconPath {
         return getThemedIconPath('DeploymentSlot_color');
+    }
+    public promptToDeploy(context: IActionContext): void {
+        const createdNewSlotMsg: string = `Created new slot "${this.root.client.fullName}": https://${this.root.client.defaultHostName}`;
+
+        // Note: intentionally not waiting for the result of this before returning
+        window.showInformationMessage(createdNewSlotMsg, AppServiceDialogResponses.deploy, AppServiceDialogResponses.viewOutput).then(async (result: MessageItem | undefined) => {
+            if (result === AppServiceDialogResponses.viewOutput) {
+                ext.outputChannel.show();
+            } else if (result === AppServiceDialogResponses.deploy) {
+                context.telemetry.properties.deploy = 'true';
+                await deploy(context, false, this);
+            }
+        });
     }
 }

--- a/src/explorer/DeploymentSlotsTreeItem.ts
+++ b/src/explorer/DeploymentSlotsTreeItem.ts
@@ -7,6 +7,7 @@ import { WebSiteManagementClient } from 'azure-arm-website';
 import { Site, WebAppCollection } from 'azure-arm-website/lib/models';
 import { createSlot, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
 import { AzureParentTreeItem, AzureTreeItem, createAzureClient, ICreateChildImplContext } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { getThemedIconPath, IThemedIconPath } from '../utils/pathUtils';
 import { DeploymentSlotTreeItem } from './DeploymentSlotTreeItem';
 import { NotAvailableTreeItem } from './NotAvailableTreeItem';
@@ -49,7 +50,12 @@ export class DeploymentSlotsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> 
     public async createChildImpl(context: ICreateChildImplContext): Promise<AzureTreeItem<ISiteTreeRoot>> {
         const existingSlots: DeploymentSlotTreeItem[] = <DeploymentSlotTreeItem[]>await this.getCachedChildren(context);
         const newSite: Site = await createSlot(this.root, existingSlots, context);
-        return new DeploymentSlotTreeItem(this, new SiteClient(newSite, this.root));
+        const siteClient: SiteClient = new SiteClient(newSite, this.root);
+
+        const createdNewSlotMsg: string = `Created new slot "${siteClient.fullName}": https://${siteClient.defaultHostName}`;
+        ext.outputChannel.appendLine(createdNewSlotMsg);
+
+        return new DeploymentSlotTreeItem(this, siteClient);
     }
 }
 

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -8,6 +8,7 @@ import { WebSiteManagementClient } from 'azure-arm-website';
 import { Site, WebAppCollection } from 'azure-arm-website/lib/models';
 import { workspace, WorkspaceConfiguration } from 'vscode';
 import { AppKind, AppServicePlanCreateStep, AppServicePlanListStep, IAppServiceWizardContext, SiteClient, SiteCreateStep, SiteNameStep, SiteOSStep, SiteRuntimeStep } from 'vscode-azureappservice';
+import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
 import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, ICreateChildImplContext, parseError, ResourceGroupCreateStep, ResourceGroupListStep, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
 import { configurationSettings, extensionPrefix } from '../constants';
 import { nonNullProp } from '../utils/nonNull';
@@ -115,6 +116,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
         // site is set as a result of SiteCreateStep.execute()
         const siteClient: SiteClient = new SiteClient(nonNullProp(wizardContext, 'site'), this.root);
+
+        const createdNewAppMsg: string = `Created new web app "${siteClient.fullName}": https://${siteClient.defaultHostName}`;
+        ext.outputChannel.appendLine(createdNewAppMsg);
 
         return new WebAppTreeItem(this, siteClient);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -206,8 +206,8 @@ export async function activateInternal(
                 node = <DeploymentSlotsTreeItem>await ext.tree.showTreeItemPicker(DeploymentSlotsTreeItem.contextValue, actionContext);
             }
 
-            const createdSlot = <SiteTreeItem>await node.createChild(actionContext);
-            createdSlot.showCreatedOutput(actionContext);
+            const createdSlot = <DeploymentSlotTreeItem>await node.createChild(actionContext);
+            createdSlot.promptToDeploy(actionContext);
         });
         registerCommand('appService.DeploySlot', async (actionContext: IActionContext, node?: DeploymentSlotTreeItem | ScaleUpTreeItem | undefined) => {
             if (!node) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1017

I wanted to leverage the `confirmDeployment` boolean that we alter when we detect the web app was created from the deployer, but it's unfortunately too late by that point 😓 