### PR TITLE
Only call getDefaultWebAppToDeploy if there was no target

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -55,15 +55,14 @@ export async function deploy(context: IDeployWizardContext, confirmDeployment: b
         }
     }
 
-    node = await getDefaultWebAppToDeploy(context);
-
     if (!node) {
         const onTreeItemCreatedFromQuickPickDisposable: Disposable = ext.tree.onTreeItemCreate((newNode: SiteTreeItem) => {
             // event is fired from azure-extensionui if node was created during deployment
             newNodes.push(newNode);
         });
         try {
-            node = <SiteTreeItem>await ext.tree.showTreeItemPicker(WebAppTreeItem.contextValue, context);
+            // tslint:disable-next-line: strict-boolean-expressions
+            node = await getDefaultWebAppToDeploy(context) || <SiteTreeItem>await ext.tree.showTreeItemPicker(WebAppTreeItem.contextValue, context);
         } catch (err2) {
             if (parseError(err2).isUserCancelledError) {
                 context.telemetry.properties.cancelStep = `showTreeItemPicker:${WebAppTreeItem.contextValue}`;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1033

Node was getting overwritten due to the defaultWebApp setting.  Because it would be undefined if there was no setting, it would always open the treeItemPicker

Now it should respect the target, then check the setting if there is no default web app, and THEN showTreeItemPicker if it's still undefined