### PR TITLE
Support new advancedCreation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,6 @@ Connecting to log stream...
 2019-01-06 07:37:33.273 INFO  - Container mahernaexpress_0 for site mahernaexpress initialized successfully.
 ```
 
-## Advanced Creation Configuration Settings
-
-* `appService.advancedCreation`
-  * Enables full control for `Create New Web App...`.  Set this to `true` to explicitly control more settings (i.e. App Service plan size) when creating web apps rather than using the defaults.
-
 ## Known Issues
 
 * Local Git deployment may fail with large commits

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "preview": true,
     "activationEvents": [
         "onCommand:appService.CreateWebApp",
+        "onCommand:appService.CreateWebAppAdvanced",
         "onCommand:appService.Refresh",
         "onCommand:appService.LoadMore",
         "onCommand:appService.OpenInPortal",
@@ -88,6 +89,11 @@
                     "light": "resources/light/createAppSvc.svg",
                     "dark": "resources/dark/createAppSvc.svg"
                 }
+            },
+            {
+                "command": "appService.CreateWebAppAdvanced",
+                "title": "Create New Web App... (Advanced)",
+                "category": "Azure App Service"
             },
             {
                 "command": "appService.Deploy",
@@ -430,9 +436,14 @@
                     "group": "1_subscriptionGeneralCommands@1"
                 },
                 {
-                    "command": "appService.OpenInPortal",
+                    "command": "appService.CreateWebAppAdvanced",
                     "when": "view == azureAppService && viewItem == azureextensionui.azureSubscription",
                     "group": "1_subscriptionGeneralCommands@2"
+                },
+                {
+                    "command": "appService.OpenInPortal",
+                    "when": "view == azureAppService && viewItem == azureextensionui.azureSubscription",
+                    "group": "1_subscriptionGeneralCommands@3"
                 },
                 {
                     "command": "appService.Refresh",
@@ -851,11 +862,6 @@
                     "scope": "resource",
                     "type": "string",
                     "description": "The default web app to use when deploying represented by its full Azure id.  Every subsequent deployment of this workspace will deploy to this web app or slot. Can be disabled by setting to \"None\""
-                },
-                "appService.advancedCreation": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enables the Advanced Web App Creation which will prompt for app name, location, website OS, runtime, resource group, and app service plan."
                 },
                 "appService.connections": {
                     "type": "array",

--- a/src/commands/createWebApp/createWebApp.ts
+++ b/src/commands/createWebApp/createWebApp.ts
@@ -3,37 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ConfigurationTarget, MessageItem, workspace, WorkspaceConfiguration } from 'vscode';
-import { AzureParentTreeItem, IActionContext, parseError } from "vscode-azureextensionui";
-import { configurationSettings, extensionPrefix } from "../../constants";
+import { AzureParentTreeItem, IActionContext, ICreateChildImplContext } from "vscode-azureextensionui";
 import { SubscriptionTreeItem } from '../../explorer/SubscriptionTreeItem';
 import { WebAppTreeItem } from "../../explorer/WebAppTreeItem";
 import { ext } from "../../extensionVariables";
 
-export async function createWebApp(context: IActionContext, node?: AzureParentTreeItem | undefined): Promise<void> {
+export async function createWebApp(context: IActionContext & Partial<ICreateChildImplContext>, node?: AzureParentTreeItem | undefined): Promise<void> {
     if (!node) {
         node = <AzureParentTreeItem>await ext.tree.showTreeItemPicker(SubscriptionTreeItem.contextValue, context);
     }
 
-    let newSite: WebAppTreeItem | undefined;
-    try {
-        newSite = <WebAppTreeItem>await node.createChild(context);
-    } catch (error) {
-        const workspaceConfig: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
-        const advancedCreation: boolean | undefined = workspaceConfig.get(configurationSettings.advancedCreation);
-        if (!parseError(error).isUserCancelledError && !advancedCreation) {
-
-            const message: string = `Modify the setting "${extensionPrefix}.${configurationSettings.advancedCreation}" if you want to change the default values when creating a Web App in Azure.`;
-            const btn: MessageItem = { title: 'Turn on advanced creation' };
-            // tslint:disable-next-line: no-floating-promises
-            ext.ui.showWarningMessage(message, btn).then(async result => {
-                if (result === btn) {
-                    await workspaceConfig.update('advancedCreation', true, ConfigurationTarget.Global);
-                }
-            });
-        }
-        throw error;
-    }
-
+    const newSite: WebAppTreeItem = <WebAppTreeItem>await node.createChild(context);
     newSite.promptToDeploy(context);
+}
+
+export async function createWebAppAdvanced(context: IActionContext, node?: AzureParentTreeItem | undefined): Promise<void> {
+    return await createWebApp({ ...context, advancedCreation: true }, node);
 }

--- a/src/commands/createWebApp/setAppWizardContextDefault.ts
+++ b/src/commands/createWebApp/setAppWizardContextDefault.ts
@@ -5,10 +5,9 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { ConfigurationTarget, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { ConfigurationTarget, workspace, WorkspaceFolder } from 'vscode';
 import { IAppServiceWizardContext, LinuxRuntimes, WebsiteOS } from 'vscode-azureappservice';
-import { IActionContext, LocationListStep } from 'vscode-azureextensionui';
-import { configurationSettings, extensionPrefix } from '../../constants';
+import { IActionContext, ICreateChildImplContext, LocationListStep } from 'vscode-azureextensionui';
 import { javaUtils } from '../../utils/javaUtils';
 import { findFilesByFileExtension, getContainingWorkspace } from '../../utils/workspace';
 
@@ -18,7 +17,7 @@ export interface IDeployWizardContext extends IActionContext {
     configurationTarget?: ConfigurationTarget;
 }
 
-export async function setAppWizardContextDefault(wizardContext: IAppServiceWizardContext & IDeployWizardContext): Promise<void> {
+export async function setAppWizardContextDefault(wizardContext: IAppServiceWizardContext & Partial<IDeployWizardContext> & Partial<ICreateChildImplContext>): Promise<void> {
     // if the user entered through "Deploy", we'll have a project to base our recommendations on
     // otherwise, look at their current workspace and only suggest if one workspace is opened
     const workspaceForRecommendation: WorkspaceFolder | undefined = wizardContext.fsPath ?
@@ -49,10 +48,7 @@ export async function setAppWizardContextDefault(wizardContext: IAppServiceWizar
         }
     }
 
-    const workspaceConfig: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
-    const advancedCreation: boolean | undefined = workspaceConfig.get(configurationSettings.advancedCreation);
-
-    if (!advancedCreation) {
+    if (!wizardContext.advancedCreation) {
         if (!wizardContext.location) {
             await LocationListStep.setLocation(wizardContext, 'centralus');
         }
@@ -71,4 +67,15 @@ export async function setAppWizardContextDefault(wizardContext: IAppServiceWizar
             }
         }
     }
+}
+
+export function resetAppWizardContextDefaults(context: Partial<IAppServiceWizardContext>): void {
+    context.plan = undefined;
+    context.newPlanName = undefined;
+    context.newPlanSku = undefined;
+
+    context.resourceGroup = undefined;
+    context.newResourceGroupName = undefined;
+    context.newSiteOS = undefined;
+    context.location = undefined;
 }

--- a/src/commands/createWebApp/setAppWizardContextDefault.ts
+++ b/src/commands/createWebApp/setAppWizardContextDefault.ts
@@ -68,14 +68,3 @@ export async function setAppWizardContextDefault(wizardContext: IAppServiceWizar
         }
     }
 }
-
-export function resetAppWizardContextDefaults(context: Partial<IAppServiceWizardContext>): void {
-    context.plan = undefined;
-    context.newPlanName = undefined;
-    context.newPlanSku = undefined;
-
-    context.resourceGroup = undefined;
-    context.newResourceGroupName = undefined;
-    context.newSiteOS = undefined;
-    context.location = undefined;
-}

--- a/src/commands/createWebApp/setDefaultRgAndPlanName.ts
+++ b/src/commands/createWebApp/setDefaultRgAndPlanName.ts
@@ -12,8 +12,6 @@ import { createAzureClient, DialogResponses } from "vscode-azureextensionui";
 import { extensionPrefix } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { nonNullProp } from "../../utils/nonNull";
-import { createWebAppAdvanced } from "./createWebApp";
-import { resetAppWizardContextDefaults } from "./setAppWizardContextDefault";
 
 const maxNumberOfSites: number = 3;
 

--- a/src/commands/createWebApp/setDefaultRgAndPlanName.ts
+++ b/src/commands/createWebApp/setDefaultRgAndPlanName.ts
@@ -89,17 +89,14 @@ async function promptPerformanceWarning(context: IAppServiceWizardContext, asp: 
 
         const numberOfSites: number = nonNullProp(asp, 'numberOfSites');
         const createAnyway: MessageItem = { title: 'Create anyway' };
-        const createNewAsp: MessageItem = { title: 'Create new App Service Plan' };
-        const inputs: MessageItem[] = [createAnyway, createNewAsp, DialogResponses.dontWarnAgain];
-        const input: MessageItem = await ext.ui.showWarningMessage(`The selected plan currently has ${numberOfSites} apps. Deploying more than ${maxNumberOfSites} apps may degrade the performance on the apps in the plan.`, { modal: true }, ...inputs);
+        const inputs: MessageItem[] = [createAnyway, DialogResponses.dontWarnAgain, DialogResponses.cancel];
+        const input: MessageItem = await ext.ui.showWarningMessage(`The selected plan currently has ${numberOfSites} apps. Deploying more than ${maxNumberOfSites} apps may degrade the performance on the apps in the plan.  Use "Create Web App... (Advanced)" to change the default resource names.`, { modal: true }, ...inputs);
 
-        if (input === createNewAsp) {
-            resetAppWizardContextDefaults(context);
-            await createWebAppAdvanced(context);
-        } else if (input === DialogResponses.dontWarnAgain) {
+        if (input === DialogResponses.dontWarnAgain) {
             context.telemetry.properties.turnOffPerfWarning = 'true';
             workspaceConfig.update(showPlanPerformanceWarningSetting, false, ConfigurationTarget.Global);
         }
+
         context.telemetry.properties.cancelStep = '';
     }
 }

--- a/src/commands/createWebApp/setDefaultRgAndPlanName.ts
+++ b/src/commands/createWebApp/setDefaultRgAndPlanName.ts
@@ -8,7 +8,7 @@ import WebSiteManagementClient from "azure-arm-website";
 import { AppServicePlan } from "azure-arm-website/lib/models";
 import { ConfigurationTarget, MessageItem, workspace, WorkspaceConfiguration } from "vscode";
 import { IAppServiceWizardContext, SiteNameStep, WebsiteOS } from "vscode-azureappservice";
-import { createAzureClient, DialogResponses } from "vscode-azureextensionui";
+import { createAzureClient, DialogResponses, IActionContext } from "vscode-azureextensionui";
 import { extensionPrefix } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { nonNullProp } from "../../utils/nonNull";
@@ -75,7 +75,7 @@ function checkPlanForPerformanceDrop(asp: AppServicePlan): boolean {
     return false;
 }
 
-async function promptPerformanceWarning(context: IAppServiceWizardContext, asp: AppServicePlan): Promise<void> {
+async function promptPerformanceWarning(context: IActionContext, asp: AppServicePlan): Promise<void> {
     context.telemetry.properties.performanceWarning = 'true';
     const workspaceConfig: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
     const showPlanPerformanceWarningSetting: string = 'showPlanPerformanceWarning';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,6 @@ export enum configurationSettings {
     zipIgnorePattern = 'zipIgnorePattern',
     showBuildDuringDeployPrompt = 'showBuildDuringDeployPrompt',
     deploySubpath = 'deploySubpath',
-    advancedCreation = 'advancedCreation',
     defaultWebAppToDeploy = 'defaultWebAppToDeploy',
     connections = 'connections'
 }
@@ -29,7 +28,6 @@ export enum ScmType {
 }
 
 export namespace AppServiceDialogResponses {
-    export const turnOnAdvancedCreation: MessageItem = { title: 'Turn on advanced creation' };
     export const deploy: MessageItem = { title: 'Deploy' };
     export const viewOutput: MessageItem = { title: 'View Output' };
 }

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -5,11 +5,9 @@
 
 import { WebSiteManagementClient } from 'azure-arm-website';
 import { Site, WebAppCollection } from 'azure-arm-website/lib/models';
-import { MessageItem } from 'vscode';
 import { AppKind, AppServicePlanCreateStep, AppServicePlanListStep, IAppServiceWizardContext, SiteClient, SiteCreateStep, SiteNameStep, SiteOSStep, SiteRuntimeStep } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, ICreateChildImplContext, parseError, ResourceGroupCreateStep, ResourceGroupListStep, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
-import { createWebAppAdvanced } from '../commands/createWebApp/createWebApp';
-import { resetAppWizardContextDefaults, setAppWizardContextDefault } from '../commands/createWebApp/setAppWizardContextDefault';
+import { setAppWizardContextDefault } from '../commands/createWebApp/setAppWizardContextDefault';
 import { setDefaultRgAndPlanName } from '../commands/createWebApp/setDefaultRgAndPlanName';
 import { ext } from '../extensionVariables';
 import { nonNullProp } from '../utils/nonNull';

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -61,7 +61,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         );
     }
 
-    public async createChildImpl(context: ICreateChildImplContext & Partial<IAppServiceWizardContext>): Promise<AzureTreeItem> {
+    public async createChildImpl(context: ICreateChildImplContext): Promise<AzureTreeItem> {
         const wizardContext: IAppServiceWizardContext = Object.assign(context, this.root, {
             newSiteKind: AppKind.app,
             resourceGroupDeferLocationStep: true

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -104,24 +104,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             await setDefaultRgAndPlanName(wizardContext, siteStep);
         }
 
-        try {
-            await wizard.execute();
-        } catch (error) {
-            if (!parseError(error).isUserCancelledError && !context.advancedCreation) {
-
-                const message: string = `Use advanced create to change the default values when creating a Web App in Azure.`;
-                const btn: MessageItem = { title: 'Create Web App... (Advanced)' };
-                // tslint:disable-next-line: no-floating-promises
-                ext.ui.showWarningMessage(message, btn).then(async result => {
-                    if (result === btn) {
-                        resetAppWizardContextDefaults(context);
-                        await createWebAppAdvanced(context);
-                    }
-                });
-            }
-            throw error;
-        }
-
+        await wizard.execute();
         context.telemetry.properties.os = wizardContext.newSiteOS;
         context.telemetry.properties.runtime = wizardContext.newSiteRuntime;
         context.telemetry.properties.advancedCreation = context.advancedCreation ? 'true' : 'false';

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -105,7 +105,6 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         await wizard.execute();
         context.telemetry.properties.os = wizardContext.newSiteOS;
         context.telemetry.properties.runtime = wizardContext.newSiteRuntime;
-        context.telemetry.properties.advancedCreation = context.advancedCreation ? 'true' : 'false';
 
         // site is set as a result of SiteCreateStep.execute()
         const siteClient: SiteClient = new SiteClient(nonNullProp(wizardContext, 'site'), this.root);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ import { removeCosmosDBConnection } from './commands/connections/removeCosmosDBC
 import { revealConnection } from './commands/connections/revealConnection';
 import { revealConnectionInAppSettings } from './commands/connections/revealConnectionInAppSettings';
 import { createSlot } from './commands/createSlot';
-import { createWebApp } from './commands/createWebApp/createWebApp';
+import { createWebApp, createWebAppAdvanced } from './commands/createWebApp/createWebApp';
 import { deploy } from './commands/deploy';
 import { connectToGitHub } from './commands/deployments/connectToGitHub';
 import { disconnectRepo } from './commands/deployments/disconnectRepo';
@@ -181,6 +181,7 @@ export async function activateInternal(
             await node.deleteTreeItem(actionContext);
         });
         registerCommand('appService.CreateWebApp', createWebApp);
+        registerCommand('appService.CreateWebAppAdvanced', createWebAppAdvanced);
         registerCommand('appService.Deploy', async (actionContext: IActionContext, target?: vscode.Uri | WebAppTreeItem | undefined) => {
             await deploy(actionContext, true, target);
         });

--- a/test/createAzureResource.test.ts
+++ b/test/createAzureResource.test.ts
@@ -17,7 +17,6 @@ suite('Create Azure Resources', async function (this: ISuiteCallbackContext): Pr
     this.timeout(1200 * 1000);
     const resourceGroupsToDelete: string[] = [];
     const testAccount: TestAzureAccount = new TestAzureAccount(vscode);
-    let oldAdvancedCreationSetting: boolean | undefined;
     const regExpLTS: RegExp = /LTS/g;
     const resourceName: string = getRandomHexString().toLowerCase();
     let webSiteClient: WebSiteManagementClient;
@@ -26,7 +25,6 @@ suite('Create Azure Resources', async function (this: ISuiteCallbackContext): Pr
         if (!longRunningTestsEnabled) {
             this.skip();
         }
-        oldAdvancedCreationSetting = <boolean>vscode.workspace.getConfiguration(constants.extensionPrefix).get('advancedCreation');
         this.timeout(120 * 1000);
         await testAccount.signIn();
         ext.azureAccountTreeItem = new AzureAccountTreeItem(testAccount);
@@ -38,7 +36,6 @@ suite('Create Azure Resources', async function (this: ISuiteCallbackContext): Pr
         if (!longRunningTestsEnabled) {
             this.skip();
         }
-        await vscode.workspace.getConfiguration(constants.extensionPrefix).update('advancedCreation', oldAdvancedCreationSetting, vscode.ConfigurationTarget.Global);
         this.timeout(1200 * 1000);
         const client: ResourceManagementClient = createAzureClient(testAccount.getSubscriptionContext(), ResourceManagementClient);
         await Promise.all(resourceGroupsToDelete.map(async resourceGroup => {
@@ -55,12 +52,11 @@ suite('Create Azure Resources', async function (this: ISuiteCallbackContext): Pr
     });
 
     test('Create New Web App (Advanced)', async () => {
-        await vscode.workspace.getConfiguration(constants.extensionPrefix).update('advancedCreation', true, vscode.ConfigurationTarget.Global);
         const testInputs: (string | RegExp)[] = [resourceName, '$(plus) Create new resource group', resourceName, 'Linux', regExpLTS, '$(plus) Create new App Service plan', resourceName, 'B1', 'West US'];
 
         resourceGroupsToDelete.push(resourceName);
         await testUserInput.runWithInputs(testInputs, async () => {
-            await vscode.commands.executeCommand('appService.CreateWebApp');
+            await vscode.commands.executeCommand('appService.CreateWebAppAdvanced');
         });
         const createdApp: WebSiteManagementModels.Site = await webSiteClient.webApps.get(resourceName, resourceName);
         assert.ok(createdApp);


### PR DESCRIPTION
Have an advanced create command rather than a setting.

Any prompt that alerted users about advanced creation has been replaced by directly calling advancedCreate for them.  I reset the context except for siteName and runtime so that the user does not have to re-enter their details.

The only hiccup with this is if they create it via deploy, but after the creation, it will include the deploy button when it has finished creating.