### PR TITLE
Check for DefaultWebApp setting before prompting

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -158,7 +158,8 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
         deployContext.telemetry.properties.cancelStep = '';
     }
 
-    if (!deployContext.deployedWithConfigs) {
+    const defaultWebAppToDeploySetting: string | undefined = getWorkspaceSetting(constants.configurationSettings.defaultWebAppToDeploy, deployFsPath);
+    if (!defaultWebAppToDeploySetting) {
         // tslint:disable-next-line:no-floating-promises
         node.promptToSaveDeployDefaults(deployContext.workspace.uri.fsPath, deployContext.deployFsPath, deployContext);
     }

--- a/src/commands/getDefaultWebAppToDeploy.ts
+++ b/src/commands/getDefaultWebAppToDeploy.ts
@@ -11,8 +11,9 @@ import { IDeployWizardContext } from "./deploy/IDeployWizardContext";
 
 export async function getDefaultWebAppToDeploy(context: IDeployWizardContext): Promise<WebAppTreeItem | undefined> {
     const defaultWebAppId: string | undefined = getWorkspaceSetting(configurationSettings.defaultWebAppToDeploy, context.workspace.uri.fsPath);
-
-    if (defaultWebAppId && defaultWebAppId !== none) {
+    if (defaultWebAppId === none) {
+        context.telemetry.properties.deployedWithConfigs = 'none';
+    } else if (defaultWebAppId) {
         const defaultWebApp: WebAppTreeItem | undefined = await ext.tree.findTreeItem(defaultWebAppId, context); // resolves to undefined if app can't be found
         if (defaultWebApp) {
             context.deployedWithConfigs = true;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1077

The previous check didn't work because `deployWithConfigs` was set to false when there wasn't a default web app.  This didn't account for the `none` behavior.

I wanted to change deployWithConfigs to include a `none` type, but `getDefaultWebApp` doesn't get called if the user entered via the context menu (since we already have a node) so I have to check the workspace setting instead.