### PR TITLE
Remove website_node_default_version setting

### DIFF
--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -109,6 +109,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         // site is set as a result of SiteCreateStep.execute()
         const siteClient: SiteClient = new SiteClient(nonNullProp(wizardContext, 'site'), this.root);
 
+        // https://github.com/microsoft/vscode-azureappservice/issues/840
         if (wizardContext.newSiteOS === WebsiteOS.windows) {
             const appSettings: StringDictionary = await siteClient.listApplicationSettings();
             if (appSettings.properties && appSettings.properties.WEBSITE_NODE_DEFAULT_VERSION) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/840

This was my least preferred solution, but looking at the portal's request to Azure to create a web app, they weren't doing anything special to prevent that setting from appearing.  

I don't think that the setting is used anymore, so it's probably just remnants from their old way of handling node versioning.