### PR TITLE
Add deployFsPath and leverage it to get subDeployPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -801,6 +801,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Shows a warning that performance may drop when creating an app in an App Service Plan that has more than 3 web apps associated to it"
+                },
+                "appService.showDeploySubpathWarning": {
+                    "type": "boolean",
+                    "description": "Show a warning when the \"deploySubpath\" setting does not match the selected folder for deploying.",
+                    "default": true
                 }
             }
         },

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -32,16 +32,15 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
     let node: SiteTreeItem | undefined;
     const newNodes: SiteTreeItem[] = [];
     context.telemetry.properties.deployedWithConfigs = 'false';
+    let siteConfig: WebSiteModels.SiteConfigResource | undefined;
 
     if (target instanceof SiteTreeItem) {
         node = target;
+        // we can only get the siteConfig earlier if the entry point was a treeItem
+        siteConfig = await node.root.client.getSiteConfig();
     }
 
-    let siteConfig: WebSiteModels.SiteConfigResource | undefined;
     let javaFileExtension: string | undefined;
-
-    // we can only get the siteConfig if the entry point was a treeItem
-    siteConfig = node ? await node.root.client.getSiteConfig() : undefined;
     if (siteConfig && javaUtils.isJavaRuntime(siteConfig.linuxFxVersion)) {
         javaFileExtension = javaUtils.getArtifactTypeByJavaRuntime(siteConfig.linuxFxVersion);
     }

--- a/src/commands/deploy/getDeployFsPath.ts
+++ b/src/commands/deploy/getDeployFsPath.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
+import { configurationSettings, extensionPrefix } from '../../constants';
+import { SiteTreeItem } from '../../explorer/SiteTreeItem';
+import { ext } from '../../extensionVariables';
+import { isPathEqual, isSubpath } from '../../utils/pathUtils';
+import * as workspaceUtil from '../../utils/workspace';
+import { getWorkspaceSetting, updateGlobalSetting } from '../../vsCodeConfig/settings';
+
+export async function getDeployFsPath(context: IActionContext, target: vscode.Uri | SiteTreeItem | undefined, fileExtension?: string): Promise<string> {
+    context.telemetry.properties.deploymentEntryPoint = target ? 'webAppContextMenu' : 'deployButton';
+    if (target instanceof vscode.Uri) {
+        context.telemetry.properties.deploymentEntryPoint = 'fileExplorerContextMenu';
+        return await appendDeploySubpathSetting(target.fsPath);
+    } else if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length === 1) {
+        // If there is only one workspace and it has 'deploySubPath' set - return that value without prompting
+        const folderPath: string = vscode.workspace.workspaceFolders[0].uri.fsPath;
+        const deploySubpath: string | undefined = getWorkspaceSetting(configurationSettings.deploySubpath, folderPath);
+        if (deploySubpath) {
+            return path.join(folderPath, deploySubpath);
+        }
+    }
+
+    const workspaceMessage: string = fileExtension ? `Select the ${fileExtension} file to deploy` : 'Select the folder to zip and deploy';
+    return fileExtension ? await workspaceUtil.selectWorkspaceItem(workspaceMessage, {}, f => getWorkspaceSetting(configurationSettings.deploySubpath, f.uri.fsPath), fileExtension) :
+        workspaceUtil.showWorkspaceFolders(workspaceMessage, context, configurationSettings.deploySubpath);
+}
+
+/**
+ * Appends the deploySubpath setting if the target path matches the root of a workspace folder
+ * If the targetPath is a sub folder instead of the root, leave the targetPath as-is and assume they want that exact folder used
+ */
+async function appendDeploySubpathSetting(targetPath: string): Promise<string> {
+    if (vscode.workspace.workspaceFolders) {
+        const deploySubPath: string | undefined = getWorkspaceSetting(configurationSettings.deploySubpath, targetPath);
+        if (deploySubPath) {
+            if (vscode.workspace.workspaceFolders.some(f => isPathEqual(f.uri.fsPath, targetPath))) {
+                return path.join(targetPath, deploySubPath);
+            } else {
+                const folder: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceFolders.find(f => isSubpath(f.uri.fsPath, targetPath));
+                if (folder) {
+                    const fsPathWithSetting: string = path.join(folder.uri.fsPath, deploySubPath);
+                    if (!isPathEqual(fsPathWithSetting, targetPath)) {
+                        const settingKey: string = 'showDeploySubpathWarning';
+                        if (getWorkspaceSetting<boolean>(settingKey)) {
+                            const selectedFolder: string = path.relative(folder.uri.fsPath, targetPath);
+                            const message: string = `Deploying "${deploySubPath}" instead of selected folder "${selectedFolder}". Use "${extensionPrefix}.${configurationSettings.deploySubpath}" to change this behavior.`;
+                            // don't wait
+                            // tslint:disable-next-line:no-floating-promises
+                            ext.ui.showWarningMessage(message, { title: 'OK' }, DialogResponses.dontWarnAgain).then(async (result: vscode.MessageItem) => {
+                                if (result === DialogResponses.dontWarnAgain) {
+                                    await updateGlobalSetting(settingKey, false);
+                                }
+                            });
+                        }
+                    }
+
+                    return fsPathWithSetting;
+                }
+            }
+        }
+    }
+
+    return targetPath;
+}

--- a/src/commands/deploy/getDeployFsPath.ts
+++ b/src/commands/deploy/getDeployFsPath.ts
@@ -28,7 +28,13 @@ export async function getDeployFsPath(context: IActionContext, target: vscode.Ur
     }
 
     const workspaceMessage: string = fileExtension ? `Select the ${fileExtension} file to deploy` : 'Select the folder to zip and deploy';
-    return fileExtension ? await workspaceUtil.selectWorkspaceItem(workspaceMessage, {}, f => getWorkspaceSetting(configurationSettings.deploySubpath, f.uri.fsPath), fileExtension) :
+    const filter: { [name: string]: string[] } = {};
+    if (fileExtension) {
+        filter[fileExtension] = [fileExtension];
+    }
+
+    return fileExtension ?
+        await workspaceUtil.selectWorkspaceItem(workspaceMessage, { filters: filter, canSelectFiles: true }, f => getWorkspaceSetting(configurationSettings.deploySubpath, f.uri.fsPath), fileExtension) :
         workspaceUtil.showWorkspaceFolders(workspaceMessage, context, configurationSettings.deploySubpath);
 }
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -55,26 +55,22 @@ export async function selectWorkspaceItem(placeHolder: string, options: vscode.O
     return folder && folder.data ? folder.data : (await ext.ui.showOpenDialog(options))[0].fsPath;
 }
 
-export async function showWorkspaceFolders(placeHolderString: string, context: IActionContext, subPathSetting: string | undefined, fileExtension?: string): Promise<string> {
+export async function showWorkspaceFolders(placeHolderString: string, context: IActionContext, subPathSetting: string | undefined): Promise<string> {
     context.telemetry.properties.cancelStep = 'showWorkspaceFoldersAndExtensions';
     return await selectWorkspaceItem(
         placeHolderString,
         {
-            // on Windows, if both files and folder are set to true, then it defaults to folders
-            canSelectFiles: true,
-            canSelectFolders: !fileExtension,
+            canSelectFiles: false,
+            canSelectFolders: true,
             canSelectMany: false,
-            defaultUri: vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri : undefined,
-            filters: { Artifacts: fileExtension ? [fileExtension] : ['jar', 'war', 'zip'] }
+            defaultUri: vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri : undefined
         },
         (f: vscode.WorkspaceFolder): string | undefined => {
             if (subPathSetting) {
                 return vscode.workspace.getConfiguration(extensionPrefix, f.uri).get(subPathSetting);
             }
             return;
-        },
-        fileExtension
-    );
+        });
 }
 
 export function getContainingWorkspace(fsPath: string): vscode.WorkspaceFolder | undefined {


### PR DESCRIPTION
Had to make some changes from the Functions repo, specifically to accept the `fileExtension` parameter.

This is used exclusively for the Java deploy scenario.  I got rid of the file selection for showWorkspaceFolders since it's supposed to be exclusively for folders anyway.