### PR TITLE
Add .NET Defaults on deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -792,6 +792,12 @@
                         }
                     }
                 },
+                "appService.configurePreDeployTasks": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "description": "Configures preDeployTasks on a deployment when true",
+                    "default": true
+                },
                 "appService.preDeployTask": {
                     "scope": "resource",
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -792,10 +792,10 @@
                         }
                     }
                 },
-                "appService.configurePreDeployTasks": {
+                "appService.showPreDeployWarning": {
                     "scope": "resource",
                     "type": "boolean",
-                    "description": "Configures preDeployTasks on a deployment when true",
+                    "description": "Shows warning that project is not configured for VS Code deployments",
                     "default": true
                 },
                 "appService.preDeployTask": {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -24,6 +24,7 @@ import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/
 import { getDefaultWebAppToDeploy } from '../getDefaultWebAppToDeploy';
 import { startStreamingLogs } from '../startStreamingLogs';
 import { IDeployWizardContext } from './IDeployWizardContext';
+import { setPreDeployTaskForDotnet } from './setPreDeployTaskForDotnet';
 
 // tslint:disable-next-line:max-func-body-length cyclomatic-complexity
 export async function deploy(context: IActionContext, confirmDeployment: boolean, target?: vscode.Uri | SiteTreeItem | undefined): Promise<void> {
@@ -163,6 +164,7 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
         node.promptToSaveDeployDefaults(deployContext.workspace.uri.fsPath, deployContext.deployFsPath, deployContext);
     }
 
+    await setPreDeployTaskForDotnet(deployContext, siteConfig);
     await appservice.runPreDeployTask(deployContext, deployContext.deployFsPath, siteConfig.scmType, constants.extensionPrefix);
 
     cancelWebsiteValidation(node);

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -154,7 +154,7 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
         node.promptToSaveDeployDefaults(deployContext.workspace.uri.fsPath, deployContext.deployFsPath, deployContext);
     }
 
-    await setPreDeployTaskForDotnet(deployContext, siteConfig);
+    await setPreDeployTaskForDotnet(deployContext);
     await appservice.runPreDeployTask(deployContext, deployContext.deployFsPath, siteConfig.scmType, constants.extensionPrefix);
 
     cancelWebsiteValidation(node);

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -125,6 +125,8 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
         }
     }
 
+    await setPreDeployTaskForDotnet(deployContext);
+
     if (confirmDeployment && siteConfig.scmType !== constants.ScmType.LocalGit && siteConfig !== constants.ScmType.GitHub) {
         const warning: string = `Are you sure you want to deploy to "${node.root.client.fullName}"? This will overwrite any previous deployment and cannot be undone.`;
         context.telemetry.properties.cancelStep = 'confirmDestructiveDeployment';
@@ -155,8 +157,6 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
 
     // tslint:disable-next-line:no-floating-promises
     node.promptToSaveDeployDefaults(deployContext, deployContext.workspace.uri.fsPath, deployContext.deployFsPath);
-
-    await setPreDeployTaskForDotnet(deployContext);
     await appservice.runPreDeployTask(deployContext, deployContext.deployFsPath, siteConfig.scmType, constants.extensionPrefix);
 
     cancelWebsiteValidation(node);

--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -3,16 +3,17 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { SiteConfig } from 'azure-arm-website/lib/models';
 import * as fse from 'fs-extra';
 import * as path from 'path';
+import { MessageItem, TaskDefinition } from 'vscode';
+import { DialogResponses } from 'vscode-azureappservice/node_modules/vscode-azureextensionui';
 import * as constants from '../../constants';
 import { ext } from '../../extensionVariables';
 import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 import * as tasks from '../../vsCodeConfig/tasks';
 import { IDeployWizardContext } from "./IDeployWizardContext";
 
-export async function setPreDeployTaskForDotnet(context: IDeployWizardContext, siteConfig: SiteConfig): Promise<void> {
+export async function setPreDeployTaskForDotnet(context: IDeployWizardContext): Promise<void> {
     const preDeployTaskSetting: string = 'preDeployTask';
     const configurePreDeployTasksSetting: string = 'configurePreDeployTasks';
     const workspaceFspath: string = context.workspace.uri.fsPath;
@@ -29,44 +30,36 @@ export async function setPreDeployTaskForDotnet(context: IDeployWizardContext, s
         return;
     }
 
-    // assume that the csProj is in the root at first
-    let csprojFile: string | undefined = await tryGetCsprojFile(context.workspace.uri.fsPath);
+    const csprojFile: string | undefined = await tryGetCsprojFile(context.workspace.uri.fsPath);
 
     // if we found a .csproj file set the tasks and workspace settings
     if (csprojFile) {
-        await ext.ui.showWarningMessage('Configure this project for deployment with VS Code?', { modal: true }, { title: 'Yes' }, { title: 'Never show again' });
-        // follow the publish output patterns, but leave out targetFramework
-        // use the absolute path so the bits are created in the root, not the subpath
-        const publishPath: string = path.posix.join('bin', 'Debug', 'publish');
+        const notConfiguredForDeploy: string = `The selected app is not configured for deployment through VS Code. Add "${preDeployTaskSetting}" and "${constants.configurationSettings.deploySubpath}" settings?`;
+        const dontShowAgainButton: MessageItem = { title: "No, and don't show again" };
+        const input: MessageItem = await ext.ui.showWarningMessage(notConfiguredForDeploy, { modal: true }, DialogResponses.yes, dontShowAgainButton);
+        if (input === dontShowAgainButton) {
+            await updateWorkspaceSetting(configurePreDeployTasksSetting, false, context.workspace.uri.fsPath);
+        } else {
+            // resolves to "."if it is not a subfolder
+            const subfolder: string = path.dirname(path.relative(context.workspace.uri.fsPath, csprojFile));
+            const deploySubpath: string = path.posix.join(subfolder, 'bin', 'Release', 'publish');
 
-        await updateWorkspaceSetting(preDeployTaskSetting, 'publish', context.workspace.uri.fsPath);
-        await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, publishPath, workspaceFspath);
+            await updateWorkspaceSetting(preDeployTaskSetting, 'publish', context.workspace.uri.fsPath);
+            await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, deploySubpath, workspaceFspath);
 
-        // update the deployContext with the .NET output path since getDeployFsPath is called prior to this
-        context.deployFsPath = path.join(context.workspace.uri.fsPath, publishPath);
+            // update the deployContext.deployFsPath with the .NET output path since getDeployFsPath is called prior to this
+            // purposely not using posix since this is happening at runtime
+            context.deployFsPath = path.join(context.workspace.uri.fsPath, deploySubpath);
 
-        // set it as the relative path
-        csprojFile = `${path.posix.normalize(path.relative(context.workspace.uri.fsPath, csprojFile))}`;
-        const publishCommand: string = `dotnet publish ${csprojFile} -o ${publishPath}`;
-        const publishTask: tasks.ITask[] = [{
-            label: 'clean',
-            command: `dotnet clean ${csprojFile}`,
-            type: 'shell'
-        },
-        {
-            label: 'publish',
-            command: publishCommand,
-            type: 'shell',
-            dependsOn: 'clean'
-        }];
-
-        tasks.updateTasks(context.workspace, publishTask);
+            const defaultTasks = getTasks(deploySubpath, subfolder);
+            tasks.updateTasks(context.workspace, defaultTasks);
+        }
 
     }
 
     async function tryGetCsprojFile(projectPath: string): Promise<string | undefined> {
         let projectFiles: string[] = await checkFolderForCsproj(projectPath);
-        // it's a common pattern to have the .csproj file in a subfolder so check one level deep
+        // it's a common pattern to have the .csproj file in a subfolder so check one level deeper
         if (projectFiles.length === 0) {
             for (const folder of fse.readdirSync(projectPath)) {
                 const filePath: string = path.join(projectPath, folder);
@@ -78,6 +71,7 @@ export async function setPreDeployTaskForDotnet(context: IDeployWizardContext, s
 
         context.telemetry.properties.numOfCsprojFiles = projectFiles.length.toString();
 
+        // if multiple csprojs were found, ignore them
         return projectFiles.length === 1 ? projectFiles[0] : undefined;
 
         async function checkFolderForCsproj(filePath: string): Promise<string[]> {
@@ -89,5 +83,30 @@ export async function setPreDeployTaskForDotnet(context: IDeployWizardContext, s
             return filePaths.filter((f: string) => /\.csproj$/i.test(f));
         }
     }
+}
 
+function getTasks(deploySubpath: string, subfolder: string): TaskDefinition[] {
+    // tslint:disable-next-line: no-unsafe-any no-invalid-template-strings
+    const cwd: string = path.posix.join('${workspaceFolder}', subfolder);
+    return [
+        {
+            label: 'clean',
+            command: 'dotnet clean',
+            type: 'shell',
+            problemMatcher: '$msCompile',
+            options: {
+                cwd
+            }
+        },
+        {
+            label: 'publish',
+            command: `dotnet publish -o ${deploySubpath}`,
+            type: 'shell',
+            dependsOn: 'clean',
+            problemMatcher: '$msCompile',
+            options: {
+                cwd
+            }
+        }
+    ];
 }

--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -43,7 +43,7 @@ export async function setPreDeployTaskForDotnet(context: IDeployWizardContext): 
 
         const notConfiguredForDeploy: string = `Required assets to build and deploy are missing from "${context.workspace.name}".`;
         const addAssetsButton: MessageItem = { title: "Add Assets" };
-        const dontShowAgainButton: MessageItem = { title: "No, and don't show again" };
+        const dontShowAgainButton: MessageItem = { title: "Don't Show Again" };
         const input: MessageItem = await ext.ui.showWarningMessage(notConfiguredForDeploy, { modal: true }, addAssetsButton, dontShowAgainButton);
         if (input === dontShowAgainButton) {
             await updateWorkspaceSetting(showPreDeployWarningSetting, false, workspaceFspath);

--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -6,10 +6,7 @@
 import { SiteConfig } from 'azure-arm-website/lib/models';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { Uri } from 'vscode';
-import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
 import * as constants from '../../constants';
-import { findFilesByFileExtension, mapFilesToQuickPickItems } from '../../utils/workspace';
 import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 import * as tasks from '../../vsCodeConfig/tasks';
 import { IDeployWizardContext } from "./IDeployWizardContext";

--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -9,83 +9,99 @@ import { MessageItem, TaskDefinition } from 'vscode';
 import { DialogResponses } from 'vscode-azureappservice/node_modules/vscode-azureextensionui';
 import * as constants from '../../constants';
 import { ext } from '../../extensionVariables';
+import { isPathEqual } from '../../utils/pathUtils';
 import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 import * as tasks from '../../vsCodeConfig/tasks';
 import { IDeployWizardContext } from "./IDeployWizardContext";
 
 export async function setPreDeployTaskForDotnet(context: IDeployWizardContext): Promise<void> {
     const preDeployTaskSetting: string = 'preDeployTask';
-    const configurePreDeployTasksSetting: string = 'configurePreDeployTasks';
+    const showPreDeployWarningSetting: string = 'showPreDeployWarning';
     const workspaceFspath: string = context.workspace.uri.fsPath;
 
     // don't overwrite preDeploy or deploySubpath if it exists and respect configurePreDeployTasks setting
-    if (!getWorkspaceSetting<boolean>(configurePreDeployTasksSetting, context.workspace.uri.fsPath)
-        || getWorkspaceSetting<string>(preDeployTaskSetting, context.workspace.uri.fsPath)
+    if (!getWorkspaceSetting<boolean>(showPreDeployWarningSetting, workspaceFspath)
+        || getWorkspaceSetting<string>(preDeployTaskSetting, workspaceFspath)
         || getWorkspaceSetting<string>(constants.configurationSettings.deploySubpath, workspaceFspath)) {
         return;
     }
 
     // if the user is deploying a different folder than the root, use this folder without setting up defaults
-    if (context.deployFsPath !== context.workspace.uri.fsPath) {
+    if (!isPathEqual(context.deployFsPath, workspaceFspath)) {
         return;
     }
 
-    const csprojFile: string | undefined = await tryGetCsprojFile(context.workspace.uri.fsPath);
+    const csprojFile: string | undefined = await tryGetCsprojFile(context, workspaceFspath);
 
     // if we found a .csproj file set the tasks and workspace settings
     if (csprojFile) {
-        const notConfiguredForDeploy: string = `The selected app is not configured for deployment through VS Code. Add "${preDeployTaskSetting}" and "${constants.configurationSettings.deploySubpath}" settings?`;
+        const notConfiguredForDeploy: string = `The selected project is not configured for deployment through VS Code. Add "${preDeployTaskSetting}" and "${constants.configurationSettings.deploySubpath}" settings?`;
         const dontShowAgainButton: MessageItem = { title: "No, and don't show again" };
         const input: MessageItem = await ext.ui.showWarningMessage(notConfiguredForDeploy, { modal: true }, DialogResponses.yes, dontShowAgainButton);
         if (input === dontShowAgainButton) {
-            await updateWorkspaceSetting(configurePreDeployTasksSetting, false, context.workspace.uri.fsPath);
+            await updateWorkspaceSetting(showPreDeployWarningSetting, false, workspaceFspath);
         } else {
             // resolves to "."if it is not a subfolder
-            const subfolder: string = path.dirname(path.relative(context.workspace.uri.fsPath, csprojFile));
+            const subfolder: string = path.dirname(path.relative(workspaceFspath, csprojFile));
+
+            // always use posix for debug config
             const deploySubpath: string = path.posix.join(subfolder, 'bin', 'Release', 'publish');
 
-            await updateWorkspaceSetting(preDeployTaskSetting, 'publish', context.workspace.uri.fsPath);
+            await updateWorkspaceSetting(preDeployTaskSetting, 'publish', workspaceFspath);
             await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, deploySubpath, workspaceFspath);
 
             // update the deployContext.deployFsPath with the .NET output path since getDeployFsPath is called prior to this
-            // purposely not using posix since this is happening at runtime
-            context.deployFsPath = path.join(context.workspace.uri.fsPath, deploySubpath);
+            context.deployFsPath = path.join(workspaceFspath, deploySubpath);
 
-            const defaultTasks = getTasks(deploySubpath, subfolder);
-            tasks.updateTasks(context.workspace, defaultTasks);
-        }
-
-    }
-
-    async function tryGetCsprojFile(projectPath: string): Promise<string | undefined> {
-        let projectFiles: string[] = await checkFolderForCsproj(projectPath);
-        // it's a common pattern to have the .csproj file in a subfolder so check one level deeper
-        if (projectFiles.length === 0) {
-            for (const folder of fse.readdirSync(projectPath)) {
-                const filePath: string = path.join(projectPath, folder);
-                if (fse.existsSync(filePath) && (await fse.stat(filePath)).isDirectory()) {
-                    projectFiles = projectFiles.concat(await checkFolderForCsproj(filePath));
+            // this will overwrite clean and publish tasks
+            const existingTasks: tasks.ITask[] = tasks.getTasks(context.workspace);
+            let dotnetTasks: tasks.ITask[] = getDotnetTasks(deploySubpath, subfolder);
+            const filteredTasks: tasks.ITask[] = existingTasks.filter(t1 => {
+                if (dotnetTasks.find(t2 => t2.label === t1.label)) {
+                    return false;
                 }
-            }
-        }
-
-        context.telemetry.properties.numOfCsprojFiles = projectFiles.length.toString();
-
-        // if multiple csprojs were found, ignore them
-        return projectFiles.length === 1 ? projectFiles[0] : undefined;
-
-        async function checkFolderForCsproj(filePath: string): Promise<string[]> {
-            const files: string[] = fse.readdirSync(filePath);
-            const filePaths: string[] = files.map((f: string) => {
-                return path.join(filePath, f);
+                return true;
             });
 
-            return filePaths.filter((f: string) => /\.csproj$/i.test(f));
+            dotnetTasks = filteredTasks.concat(dotnetTasks);
+
+            tasks.updateTasks(context.workspace, dotnetTasks);
         }
+
     }
 }
 
-function getTasks(deploySubpath: string, subfolder: string): TaskDefinition[] {
+async function tryGetCsprojFile(context: IDeployWizardContext, projectPath: string): Promise<string | undefined> {
+    let projectFiles: string[] = await checkFolderForCsproj(projectPath);
+    // it's a common pattern to have the .csproj file in a subfolder so check one level deeper
+    if (projectFiles.length === 0) {
+        const subfolders: string[] = await fse.readdir(projectPath);
+        await Promise.all(subfolders.map(async folder => {
+            const filePath: string = path.join(projectPath, folder);
+            // check its existence as this will check .vscode even if the project doesn't contain that folder
+            if (fse.existsSync(filePath) && (await fse.stat(filePath)).isDirectory()) {
+                projectFiles = projectFiles.concat(await checkFolderForCsproj(filePath));
+            }
+        }));
+    }
+
+    context.telemetry.properties.numOfCsprojFiles = projectFiles.length.toString();
+
+    // if multiple csprojs were found, ignore them
+    return projectFiles.length === 1 ? projectFiles[0] : undefined;
+
+    async function checkFolderForCsproj(filePath: string): Promise<string[]> {
+        const files: string[] = fse.readdirSync(filePath);
+        const filePaths: string[] = files.map((f: string) => {
+            return path.join(filePath, f);
+        });
+
+        return filePaths.filter((f: string) => /\.csproj$/i.test(f));
+    }
+}
+
+function getDotnetTasks(deploySubpath: string, subfolder: string): TaskDefinition[] {
+    // always use posix for debug config
     // tslint:disable-next-line: no-unsafe-any no-invalid-template-strings
     const cwd: string = path.posix.join('${workspaceFolder}', subfolder);
     return [

--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -105,13 +105,11 @@ async function tryGetCsprojFile(context: IDeployWizardContext, projectPath: stri
     }
 }
 
-
 async function tryGetTargetFramework(projFilePath: string): Promise<string | undefined> {
     const projContents: string = (await fse.readFile(projFilePath)).toString();
     const matches: RegExpMatchArray | null = projContents.match(/<TargetFramework>(.*)<\/TargetFramework>/);
     return matches === null ? undefined : matches[1];
 }
-
 
 function generateDotnetTasks(subfolder: string): TaskDefinition[] {
     // always use posix for debug config

--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { SiteConfig } from 'azure-arm-website/lib/models';
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { Uri } from 'vscode';
+import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
+import * as constants from '../../constants';
+import { findFilesByFileExtension, mapFilesToQuickPickItems } from '../../utils/workspace';
+import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
+import * as tasks from '../../vsCodeConfig/tasks';
+import { IDeployWizardContext } from "./IDeployWizardContext";
+
+export async function setPreDeployTaskForDotnet(context: IDeployWizardContext, siteConfig: SiteConfig): Promise<void> {
+    // don't overwrite preDeploy task if it exists
+    if (!getWorkspaceSetting<boolean>('configurePreDeployTasks', context.workspace.uri.fsPath) || getWorkspaceSetting<boolean>(constants.configurationSettings.preDeployTask, context.workspace.uri.fsPath)) {
+        return;
+    }
+
+    // assume that the csProj is in the root
+    let csProjFsPath: string = context.workspace.uri.fsPath;
+
+    const csprojFile: string | undefined = await tryGetCsprojFile(csProjFsPath);
+
+    if (csprojFile) {
+        csProjFsPath = path.dirname(csProjFsPath);
+    }
+
+    // if we found a csproj file or we know the app is .NET, go ahead and set the tasks and workspace settings
+    if (csprojFile || (siteConfig.linuxFxVersion && siteConfig.linuxFxVersion.toLowerCase().includes('dotnet'))) {
+        // follow the publish output patterns, but leave out targetFramework
+        // use the absolute path so the bits are created in the root, not the subpath
+        const dotnetOutputPath: string = path.join(csProjFsPath, 'bin', 'Debug', 'publish');
+
+        const preDeployTaskSetting: string = 'preDeployTask';
+        await updateWorkspaceSetting(preDeployTaskSetting, 'publish', context.workspace.uri.fsPath);
+        await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, dotnetOutputPath, context.workspace.uri.fsPath);
+
+        const publishCommand: string = `dotnet publish ${csProjFsPath} -o ${dotnetOutputPath}`;
+        const publishTask: tasks.ITask[] = [{
+            label: 'clean',
+            command: `dotnet clean ${csProjFsPath}`,
+            type: 'shell'
+        },
+        {
+            label: 'publish',
+            command: publishCommand,
+            type: 'shell',
+            dependsOn: 'clean'
+        }];
+
+        tasks.updateTasks(context.workspace, publishTask);
+
+    }
+
+    async function tryGetCsprojFile(projectPath: string): Promise<string | undefined> {
+        const projectFiles: string[] = await checkFolderForCsproj(projectPath);
+        // it's a common pattern to have the .csproj file in a subfolder
+        if (projectFiles.length === 0) {
+            for (const folder of await fse.readdir(projectPath)) {
+                if ((await fse.stat(folder)).isDirectory()) {
+                    projectFiles.concat(await checkFolderForCsproj(folder));
+                }
+            }
+        }
+
+        context.telemetry.properties.numOfCsprojFiles = projectFiles.length.toString();
+
+        return projectFiles.length === 1 ? projectFiles[0] : undefined;
+
+        async function checkFolderForCsproj(filePath: string): Promise<string[]> {
+            const files: string[] = await fse.readdir(filePath);
+            return files.filter((f: string) => /\.csproj$/i.test(f));
+        }
+    }
+
+}

--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -151,18 +151,17 @@ export abstract class SiteTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public async promptScmDoBuildDeploy(fsPath: string, runtime: string, context: IActionContext): Promise<void> {
-        const yesButton: MessageItem = { title: 'Yes' };
         const dontShowAgainButton: MessageItem = { title: "No, and don't show again" };
         const learnMoreButton: MessageItem = { title: 'Learn More' };
         const buildDuringDeploy: string = `Would you like to update your workspace configuration to run build commands on the target server? This should improve deployment performance.`;
         let input: MessageItem | undefined = learnMoreButton;
         while (input === learnMoreButton) {
-            input = await window.showInformationMessage(buildDuringDeploy, yesButton, dontShowAgainButton, learnMoreButton);
+            input = await window.showInformationMessage(buildDuringDeploy, DialogResponses.yes, dontShowAgainButton, learnMoreButton);
             if (input === learnMoreButton) {
                 await openUrl('https://aka.ms/Kwwkbd');
             }
         }
-        if (input === yesButton) {
+        if (input === DialogResponses.yes) {
             await this.enableScmDoBuildDuringDeploy(fsPath, runtime);
             context.telemetry.properties.enableScmInput = "Yes";
         } else {

--- a/src/vsCodeConfig/tasks.ts
+++ b/src/vsCodeConfig/tasks.ts
@@ -32,26 +32,3 @@ export interface ITaskOptions {
         [key: string]: string;
     };
 }
-
-export function insertNewTasks(existingTasks: ITask[] | undefined, newTasks: ITask[]): ITask[] {
-    // tslint:disable-next-line: strict-boolean-expressions
-    existingTasks = existingTasks || [];
-    // Remove tasks that match the ones we're about to add
-    existingTasks = existingTasks.filter(t1 => !newTasks.find(t2 => {
-        if (t1.type === t2.type) {
-            switch (t1.type) {
-                case 'shell':
-                case 'process':
-                    return t1.label === t2.label && t1.identifier === t2.identifier;
-                default:
-                    // Not worth throwing an error for unrecognized task type
-                    // Worst case the user has an extra task in their tasks.json
-                    return false;
-            }
-        } else {
-            return false;
-        }
-    }));
-    existingTasks.push(...newTasks);
-    return existingTasks;
-}

--- a/src/vsCodeConfig/tasks.ts
+++ b/src/vsCodeConfig/tasks.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TaskDefinition, workspace, WorkspaceConfiguration, WorkspaceFolder } from "vscode";
+
+const tasksKey: string = 'tasks';
+
+export function updateTasks(folder: WorkspaceFolder, tasks: ITask[]): void {
+    getTasksConfig(folder).update(tasksKey, tasks);
+}
+
+function getTasksConfig(folder: WorkspaceFolder): WorkspaceConfiguration {
+    return workspace.getConfiguration(tasksKey, folder.uri);
+}
+
+export interface ITask extends TaskDefinition {
+    label?: string;
+    command?: string;
+    options?: ITaskOptions;
+}
+
+export interface ITaskOptions {
+    cwd?: string;
+    env?: {
+        [key: string]: string;
+    };
+}

--- a/src/vsCodeConfig/tasks.ts
+++ b/src/vsCodeConfig/tasks.ts
@@ -32,3 +32,26 @@ export interface ITaskOptions {
         [key: string]: string;
     };
 }
+
+export function insertNewTasks(existingTasks: ITask[] | undefined, newTasks: ITask[]): ITask[] {
+    // tslint:disable-next-line: strict-boolean-expressions
+    existingTasks = existingTasks || [];
+    // Remove tasks that match the ones we're about to add
+    existingTasks = existingTasks.filter(t1 => !newTasks.find(t2 => {
+        if (t1.type === t2.type) {
+            switch (t1.type) {
+                case 'shell':
+                case 'process':
+                    return t1.label === t2.label && t1.identifier === t2.identifier;
+                default:
+                    // Not worth throwing an error for unrecognized task type
+                    // Worst case the user has an extra task in their tasks.json
+                    return false;
+            }
+        } else {
+            return false;
+        }
+    }));
+    existingTasks.push(...newTasks);
+    return existingTasks;
+}

--- a/src/vsCodeConfig/tasks.ts
+++ b/src/vsCodeConfig/tasks.ts
@@ -7,6 +7,11 @@ import { TaskDefinition, workspace, WorkspaceConfiguration, WorkspaceFolder } fr
 
 const tasksKey: string = 'tasks';
 
+export function getTasks(folder: WorkspaceFolder): ITask[] {
+    // tslint:disable-next-line: strict-boolean-expressions
+    return getTasksConfig(folder).get<ITask[]>(tasksKey) || [];
+}
+
 export function updateTasks(folder: WorkspaceFolder, tasks: ITask[]): void {
     getTasksConfig(folder).update(tasksKey, tasks);
 }


### PR DESCRIPTION
Fixes #945 

For now, we are only looking for `csproj` files in the root and its subfolders.  If we find multiple `csproj` files in one project, we assume that the `csproj` is in the user's root path. If a `csproj` file was not found, but the app has a .NET runtime, we also assume the `csproj` is in the root path (it probably won't be, but this will write the tasks and settings for the user so that they can discover/edit as needed)

We don't support multiple frameworks as we only use the `publish` command without a target framework.  Users will see errors when running `publish` with a `csproj` that contains multiple frameworks, so they will be able to edit it accordingly.  

I'd assume a user who is in an advanced scenario and is configuring a project for multiple frameworks is probably already used to this process.