### PR TITLE
Add AppInsights steps to site creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7825,9 +7825,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.43.4",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.43.4.tgz",
-            "integrity": "sha512-QEVCQ/p8C4wPHAxWQuGajAxcyvK5UMZarmOEGGGgy6J9p8BNX3iYsWTx5z490neOxeydXechOelKqXPU4CuS4Q==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.44.0.tgz",
+            "integrity": "sha512-GxkrntrbPxVgjKXeH8Q/hyebrk1BQYwSCozsbd81BEtR9UiV+EMkP8/YQAOiUiY5qXv7MvToxsFjVQR7FrMWvA==",
             "requires": {
                 "archiver": "^3.0.0",
                 "azure-arm-appinsights": "^2.1.0",
@@ -7848,25 +7848,6 @@
                 "vscode-azurekudu": "^0.1.9",
                 "vscode-nls": "^4.0.0",
                 "websocket": "^1.0.25"
-            },
-            "dependencies": {
-                "vscode-azureextensionui": {
-                    "version": "0.27.0",
-                    "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.27.0.tgz",
-                    "integrity": "sha512-4gMeJWIZ8WRNBmJJ2G2KE0FXr7Uvos4g3WBG3zbR1pLvpQAqI1TqwniM3wxV3yqNvf2px7UgBpvP5n+fYv6jWw==",
-                    "requires": {
-                        "azure-arm-resource": "^3.0.0-preview",
-                        "azure-arm-storage": "^3.1.0",
-                        "fs-extra": "^4.0.3",
-                        "html-to-text": "^4.0.0",
-                        "ms-rest": "^2.2.2",
-                        "ms-rest-azure": "^2.4.4",
-                        "opn": "^6.0.0",
-                        "semver": "^5.6.0",
-                        "vscode-extension-telemetry": "^0.1.0",
-                        "vscode-nls": "^4.0.0"
-                    }
-                }
             }
         },
         "vscode-azureextensiondev": {

--- a/package.json
+++ b/package.json
@@ -856,7 +856,7 @@
         "fs-extra": "^4.0.2",
         "portfinder": "^1.0.13",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "^0.43.4",
+        "vscode-azureappservice": "^0.43.5",
         "vscode-azureextensionui": "^0.27.0",
         "vscode-azurekudu": "^0.1.8"
     },

--- a/package.json
+++ b/package.json
@@ -856,7 +856,7 @@
         "fs-extra": "^4.0.2",
         "portfinder": "^1.0.13",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "^0.43.5",
+        "vscode-azureappservice": "^0.44.0",
         "vscode-azureextensionui": "^0.27.0",
         "vscode-azurekudu": "^0.1.8"
     },

--- a/src/commands/createWebApp/setDefaultRgAndPlanName.ts
+++ b/src/commands/createWebApp/setDefaultRgAndPlanName.ts
@@ -49,6 +49,10 @@ export async function setDefaultRgAndPlanName(wizardContext: IAppServiceWizardCo
 
             // otherwise create a new rg and asp
             wizardContext.newResourceGroupName = wizardContext.newResourceGroupName || await siteNameStep.getRelatedName(wizardContext, defaultName);
+            if (!wizardContext.newResourceGroupName) {
+                throw new Error('Failed to generate unique name for resources. Use advanced creation to manually enter resource names.');
+            }
+
             wizardContext.newPlanName = wizardContext.newResourceGroupName;
         }
     } else {

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -105,6 +105,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         if (!context.advancedCreation) {
             await setDefaultRgAndPlanName(wizardContext, siteStep);
             wizardContext.newAppInsightsName = await wizardContext.relatedNameTask;
+            if (!wizardContext.newAppInsightsName) {
+                throw new Error('Failed to generate unique name for resources. Use advanced creation to manually enter resource names.');
+            }
         }
 
         await wizard.execute();
@@ -132,38 +135,39 @@ async function createWebAppSettings(context: IAppSettingsContext): Promise<WebSi
 
         // all these settings are set on the portal if AI is enabled for Windows apps
         if (context.os === WebsiteOS.windows) {
-            appSettings.push({
-                name: 'APPINSIGHTS_PROFILERFEATURE_VERSION',
-                value: disabled
-            });
-            appSettings.push({
-                name: 'APPINSIGHTS_SNAPSHOTFEATURE_VERSION',
-                value: disabled
-            });
-            appSettings.push({
-                name: 'ApplicationInsightsAgent_EXTENSION_VERSION',
-                value: '~2'
-            });
-            appSettings.push({
-                name: 'DiagnosticServices_EXTENSION_VERSION',
-                value: disabled
-            });
-            appSettings.push({
-                name: 'InstrumentationEngine_EXTENSION_VERSION',
-                value: disabled
-            });
-            appSettings.push({
-                name: 'SnapshotDebugger_EXTENSION_VERSION',
-                value: disabled
-            });
-            appSettings.push({
-                name: 'XDT_MicrosoftApplicationInsights_BaseExtensions',
-                value: disabled
-            });
-            appSettings.push({
-                name: 'XDT_MicrosoftApplicationInsights_Mode',
-                value: 'default'
-            });
+            appSettings.push(
+                {
+                    name: 'APPINSIGHTS_PROFILERFEATURE_VERSION',
+                    value: disabled
+                },
+                {
+                    name: 'APPINSIGHTS_SNAPSHOTFEATURE_VERSION',
+                    value: disabled
+                },
+                {
+                    name: 'ApplicationInsightsAgent_EXTENSION_VERSION',
+                    value: '~2'
+                },
+                {
+                    name: 'DiagnosticServices_EXTENSION_VERSION',
+                    value: disabled
+                },
+                {
+                    name: 'InstrumentationEngine_EXTENSION_VERSION',
+                    value: disabled
+                },
+                {
+                    name: 'SnapshotDebugger_EXTENSION_VERSION',
+                    value: disabled
+                },
+                {
+                    name: 'XDT_MicrosoftApplicationInsights_BaseExtensions',
+                    value: disabled
+                },
+                {
+                    name: 'XDT_MicrosoftApplicationInsights_Mode',
+                    value: 'default'
+                });
         } else {
             appSettings.push({
                 name: 'APPLICATIONINSIGHTSAGENT_EXTENSION_ENABLED',

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { WebSiteManagementClient } from 'azure-arm-website';
 import { Site, StringDictionary, WebAppCollection } from 'azure-arm-website/lib/models';
-import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, AppServicePlanListStep, IAppServiceWizardContext, SiteClient, SiteCreateStep, SiteNameStep, SiteOSStep, SiteRuntimeStep } from 'vscode-azureappservice';
+import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, AppServicePlanListStep, IAppServiceWizardContext, SiteClient, SiteCreateStep, SiteNameStep, SiteOSStep, SiteRuntimeStep, WebsiteOS } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, ICreateChildImplContext, parseError, ResourceGroupCreateStep, ResourceGroupListStep, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
 import { setAppWizardContextDefault } from '../commands/createWebApp/setAppWizardContextDefault';
 import { setDefaultRgAndPlanName } from '../commands/createWebApp/setDefaultRgAndPlanName';
@@ -123,7 +123,19 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             }
 
             appSettings.properties.APPINSIGHTS_INSTRUMENTATIONKEY = wizardContext.appInsightsComponent.instrumentationKey;
-            appSettings.properties.APPLICATIONINSIGHTSAGENT_EXTENSION_ENABLED = 'true';
+            if (wizardContext.newSiteOS === WebsiteOS.windows) {
+                // all these settings are set on the portal if AI is enabled for Windows apps
+                appSettings.properties.APPINSIGHTS_PROFILERFEATURE_VERSION = 'disabled';
+                appSettings.properties.APPINSIGHTS_SNAPSHOTFEATURE_VERSION = 'disabled';
+                appSettings.properties.ApplicationInsightsAgent_EXTENSION_VERSION = '~2';
+                appSettings.properties.DiagnosticServices_EXTENSION_VERSION = 'disabled';
+                appSettings.properties.InstrumentationEngine_EXTENSION_VERSION = 'disabled';
+                appSettings.properties.SnapshotDebugger_EXTENSION_VERSION = 'disabled';
+                appSettings.properties.XDT_MicrosoftApplicationInsights_BaseExtensions = 'disabled';
+                appSettings.properties.XDT_MicrosoftApplicationInsights_Mode = 'default';
+            } else {
+                appSettings.properties.APPLICATIONINSIGHTSAGENT_EXTENSION_ENABLED = 'true';
+            }
             await siteClient.updateApplicationSettings(appSettings);
         }
 

--- a/src/explorer/SubscriptionTreeItem.ts
+++ b/src/explorer/SubscriptionTreeItem.ts
@@ -124,14 +124,15 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
             appSettings.properties.APPINSIGHTS_INSTRUMENTATIONKEY = wizardContext.appInsightsComponent.instrumentationKey;
             if (wizardContext.newSiteOS === WebsiteOS.windows) {
+                const disabled: string = 'disabled';
                 // all these settings are set on the portal if AI is enabled for Windows apps
-                appSettings.properties.APPINSIGHTS_PROFILERFEATURE_VERSION = 'disabled';
-                appSettings.properties.APPINSIGHTS_SNAPSHOTFEATURE_VERSION = 'disabled';
+                appSettings.properties.APPINSIGHTS_PROFILERFEATURE_VERSION = disabled;
+                appSettings.properties.APPINSIGHTS_SNAPSHOTFEATURE_VERSION = disabled;
                 appSettings.properties.ApplicationInsightsAgent_EXTENSION_VERSION = '~2';
-                appSettings.properties.DiagnosticServices_EXTENSION_VERSION = 'disabled';
-                appSettings.properties.InstrumentationEngine_EXTENSION_VERSION = 'disabled';
-                appSettings.properties.SnapshotDebugger_EXTENSION_VERSION = 'disabled';
-                appSettings.properties.XDT_MicrosoftApplicationInsights_BaseExtensions = 'disabled';
+                appSettings.properties.DiagnosticServices_EXTENSION_VERSION = disabled;
+                appSettings.properties.InstrumentationEngine_EXTENSION_VERSION = disabled;
+                appSettings.properties.SnapshotDebugger_EXTENSION_VERSION = disabled;
+                appSettings.properties.XDT_MicrosoftApplicationInsights_BaseExtensions = disabled;
                 appSettings.properties.XDT_MicrosoftApplicationInsights_Mode = 'default';
             } else {
                 appSettings.properties.APPLICATIONINSIGHTSAGENT_EXTENSION_ENABLED = 'true';

--- a/test/createAzureResource.test.ts
+++ b/test/createAzureResource.test.ts
@@ -52,7 +52,7 @@ suite('Create Azure Resources', async function (this: ISuiteCallbackContext): Pr
     });
 
     test('Create New Web App (Advanced)', async () => {
-        const testInputs: (string | RegExp)[] = [resourceName, '$(plus) Create new resource group', resourceName, 'Linux', regExpLTS, '$(plus) Create new App Service plan', resourceName, 'B1', 'West US'];
+        const testInputs: (string | RegExp)[] = [resourceName, '$(plus) Create new resource group', resourceName, 'Linux', regExpLTS, '$(plus) Create new App Service plan', resourceName, 'B1', '$(plus) Create new Application Insights resource', resourceName, 'West US'];
 
         resourceGroupsToDelete.push(resourceName);
         await testUserInput.runWithInputs(testInputs, async () => {


### PR DESCRIPTION
Fixes #222 

For Linux apps, there are a couple of settings we need 
 
> `APPINSIGHTS_INSTRUMENTATIONKEY` I think you’re already setting this
> `APPLICATIONINSIGHTSAGENT_EXTENSION_ENABLED` set to “true”

I copied the settings from the portal for Windows app when AI is enabled.
