### PR TITLE
Fixed isJavaProject returns true if there is no project opened

### DIFF
--- a/src/utils/javaUtils.ts
+++ b/src/utils/javaUtils.ts
@@ -68,7 +68,8 @@ export namespace javaUtils {
             return await isJavaFolder(deployFsPath) || isJavaArtifact(deployFsPath);
         }
 
-        if (!workspace.workspaceFolders) {
+        // if there's no workspace, it can return an empty array
+        if (!workspace.workspaceFolders || workspace.workspaceFolders.length === 0) {
             return false;
         }
 


### PR DESCRIPTION
If workspaceFolders was an empty array, the old check wouldn't work and it was returning as a javaProject, prompting users for a .jar/.war file