### PR TITLE
Add validation for Linux webapp setting names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8142,9 +8142,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.45.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.45.0.tgz",
-            "integrity": "sha512-ITz0zMkOxEi8GOFfBX8sq+Fq5fAM0JNjXVrEMI1Nf+3sKC/21EwT5J6M72OwiGz8VBOC7SAFudvE9c9/d30c0w==",
+            "version": "0.46.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.46.0.tgz",
+            "integrity": "sha512-8UgmpbI+jnGWQ4OaZzfMhorEdhIoRQJzKEitTpH09MskalyjNfACNW4sKQ0UtCwQ3DNcX9yco4t++0DLrgZh4Q==",
             "requires": {
                 "archiver": "^3.0.0",
                 "azure-arm-appinsights": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -872,7 +872,7 @@
         "fs-extra": "^4.0.2",
         "portfinder": "^1.0.13",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "^0.45.0",
+        "vscode-azureappservice": "^0.46.0",
         "vscode-azureextensionui": "^0.28.1",
         "vscode-azurekudu": "^0.1.8"
     },

--- a/src/explorer/CosmosDBTreeItem.ts
+++ b/src/explorer/CosmosDBTreeItem.ts
@@ -202,7 +202,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
 
         const appSettingKey: string = await ext.ui.showInputBox({
             prompt,
-            validateInput: (v?: string): string | undefined => validateAppSettingKey(appSettingsDict, v),
+            validateInput: (v?: string): string | undefined => validateAppSettingKey(appSettingsDict, this.root.client, v),
             value: defaultKey
         });
 
@@ -219,7 +219,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
                 if (!v) {
                     return "Connection setting prefix cannot be empty.";
                 } else {
-                    return validateAppSettingKey(appSettingsDict, v + this._endpointSuffix) || validateAppSettingKey(appSettingsDict, v + this._keySuffix) || validateAppSettingKey(appSettingsDict, v + this._databaseSuffix);
+                    return validateAppSettingKey(appSettingsDict, this.root.client, v + this._endpointSuffix) || validateAppSettingKey(appSettingsDict, this.root.client, v + this._keySuffix) || validateAppSettingKey(appSettingsDict, this.root.client, v + this._databaseSuffix);
                 }
             },
             value: defaultPrefix


### PR DESCRIPTION
Fixes #646

This accounts for breaking changes introduced by requiring `SiteClient` as a parameter for `validateAppSettingKey`.