### PR TITLE
Leverage new getDeployPath. Ignores subpath for local git deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8142,9 +8142,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.46.0.tgz",
-            "integrity": "sha512-8UgmpbI+jnGWQ4OaZzfMhorEdhIoRQJzKEitTpH09MskalyjNfACNW4sKQ0UtCwQ3DNcX9yco4t++0DLrgZh4Q==",
+            "version": "0.47.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.47.0.tgz",
+            "integrity": "sha512-SwE9tNrHiIr3G1bLdzqPtJzBpys/SO11xgoa97klp8k3uemGqBlDxcul2uN+Ra+WvGoLUVMbKtcsRzG13e12QA==",
             "requires": {
                 "archiver": "^3.0.0",
                 "azure-arm-appinsights": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -872,7 +872,7 @@
         "fs-extra": "^4.0.2",
         "portfinder": "^1.0.13",
         "request-promise": "^4.2.2",
-        "vscode-azureappservice": "^0.46.0",
+        "vscode-azureappservice": "^0.47.0",
         "vscode-azureextensionui": "^0.28.1",
         "vscode-azurekudu": "^0.1.8"
     },

--- a/src/commands/deploy/IDeployWizardContext.ts
+++ b/src/commands/deploy/IDeployWizardContext.ts
@@ -8,8 +8,8 @@ import { IActionContext } from "vscode-azureextensionui";
 
 export interface IDeployWizardContext extends IActionContext {
     workspace: WorkspaceFolder;
-    deployFsPath: string;
-    deployFsSubpath: string;
+    originalDeployFsPath: string;
+    effectiveDeployFsPath: string;
     webAppSource?: WebAppSource;
 }
 

--- a/src/commands/deploy/IDeployWizardContext.ts
+++ b/src/commands/deploy/IDeployWizardContext.ts
@@ -9,6 +9,7 @@ import { IActionContext } from "vscode-azureextensionui";
 export interface IDeployWizardContext extends IActionContext {
     workspace: WorkspaceFolder;
     deployFsPath: string;
+    deployFsSubpath: string;
     webAppSource?: WebAppSource;
 }
 

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -167,6 +167,11 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
     // only respect the deploySubpath settings for zipdeploys
     const deployPath: string = siteConfig.scmType === constants.ScmType.None ? deployContext.effectiveDeployFsPath : deployContext.originalDeployFsPath;
 
+    if (siteConfig.scmType !== constants.ScmType.None && deployContext.effectiveDeployFsPath !== deployContext.originalDeployFsPath) {
+        const noSubpathWarning: string = `WARNING: Ignoring deploySubPath "${getWorkspaceSetting(constants.configurationSettings.deploySubpath)}" for non-zip deploy.`;
+        ext.outputChannel.appendLog(noSubpathWarning);
+    }
+
     await node.runWithTemporaryDescription("Deploying...", async () => {
         await appservice.deploy(nonNullValue(node).root.client, <string>deployPath, deployContext, constants.showOutputChannelCommandId);
     });

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -51,14 +51,14 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
         fileExtensions = javaUtils.getJavaArtifactExtensions();
     }
 
-    const { deployFsPath, deployFsSubpath } = await appservice.getDeployFsPath(target, constants.extensionPrefix, fileExtensions);
-    const workspace: vscode.WorkspaceFolder | undefined = workspaceUtil.getContainingWorkspace(deployFsSubpath);
+    const { originalDeployFsPath, effectiveDeployFsPath } = await appservice.getDeployFsPath(target, constants.extensionPrefix, fileExtensions);
+    const workspace: vscode.WorkspaceFolder | undefined = workspaceUtil.getContainingWorkspace(effectiveDeployFsPath);
     if (!workspace) {
         throw new Error('Failed to deploy because the path is not part of an open workspace. Open in a workspace and try again.');
     }
 
     const deployContext: IDeployWizardContext = {
-        ...context, workspace, deployFsPath, deployFsSubpath, webAppSource
+        ...context, workspace, deployFsPath: originalDeployFsPath, deployFsSubpath: effectiveDeployFsPath, webAppSource
     };
 
     // because this is workspace dependant, do it before user selects app

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -58,7 +58,7 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
     }
 
     const deployContext: IDeployWizardContext = {
-        ...context, workspace, deployFsPath: originalDeployFsPath, deployFsSubpath: effectiveDeployFsPath, webAppSource
+        ...context, workspace, originalDeployFsPath, effectiveDeployFsPath, webAppSource
     };
 
     // because this is workspace dependant, do it before user selects app
@@ -154,8 +154,8 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
     }
 
     // tslint:disable-next-line:no-floating-promises
-    node.promptToSaveDeployDefaults(deployContext, deployContext.workspace.uri.fsPath, deployContext.deployFsPath);
-    await appservice.runPreDeployTask(deployContext, deployContext.deployFsPath, siteConfig.scmType, constants.extensionPrefix);
+    node.promptToSaveDeployDefaults(deployContext, deployContext.workspace.uri.fsPath, deployContext.originalDeployFsPath);
+    await appservice.runPreDeployTask(deployContext, deployContext.originalDeployFsPath, siteConfig.scmType, constants.extensionPrefix);
 
     // cancellation moved to after prompts while gathering telemetry
     // cancel the previous detector check from the same web app
@@ -165,7 +165,7 @@ export async function deploy(context: IActionContext, confirmDeployment: boolean
     }
 
     // only respect the deploySubpath settings for zipdeploys
-    const deployPath: string = siteConfig.scmType === constants.ScmType.None ? deployContext.deployFsSubpath : deployContext.deployFsPath;
+    const deployPath: string = siteConfig.scmType === constants.ScmType.None ? deployContext.effectiveDeployFsPath : deployContext.originalDeployFsPath;
 
     await node.runWithTemporaryDescription("Deploying...", async () => {
         await appservice.deploy(nonNullValue(node).root.client, <string>deployPath, deployContext, constants.showOutputChannelCommandId);

--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -29,7 +29,7 @@ export async function setPreDeployTaskForDotnet(context: IDeployWizardContext): 
     }
 
     // if the user is deploying a different folder than the root, use this folder without setting up defaults
-    if (!isPathEqual(context.deployFsPath, workspaceFspath)) {
+    if (!isPathEqual(context.originalDeployFsPath, workspaceFspath)) {
         return;
     }
 
@@ -59,7 +59,7 @@ export async function setPreDeployTaskForDotnet(context: IDeployWizardContext): 
         await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, deploySubpath, workspaceFspath);
 
         // update the deployContext.deployFsPath with the .NET output path since getDeployFsPath is called prior to this
-        context.deployFsPath = path.join(workspaceFspath, deploySubpath);
+        context.originalDeployFsPath = path.join(workspaceFspath, deploySubpath);
 
         const existingTasks: tasks.ITask[] = tasks.getTasks(context.workspace);
         const publishTask: tasks.ITask | undefined = existingTasks.find(t1 => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1185

Relies on https://github.com/microsoft/vscode-azuretools/pull/595