### PR TITLE
Update effectiveDeployFsPath

### DIFF
--- a/src/commands/deploy/setPreDeployTaskForDotnet.ts
+++ b/src/commands/deploy/setPreDeployTaskForDotnet.ts
@@ -58,8 +58,8 @@ export async function setPreDeployTaskForDotnet(context: IDeployContext): Promis
         await updateWorkspaceSetting(preDeployTaskSetting, publishId, workspaceFspath);
         await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, deploySubpath, workspaceFspath);
 
-        // update the deployContext.deployFsPath with the .NET output path since getDeployFsPath is called prior to this
-        context.originalDeployFsPath = path.join(workspaceFspath, deploySubpath);
+        // update the deployContext.effectiveDeployPath with the .NET output path since getDeployFsPath is called prior to this
+        context.effectiveDeployFsPath = path.join(workspaceFspath, deploySubpath);
 
         const existingTasks: tasks.ITask[] = tasks.getTasks(context.workspace);
         const publishTask: tasks.ITask | undefined = existingTasks.find(t1 => {


### PR DESCRIPTION
On the first deploy with a local git project, the 'constructor' of undefined error would appear because I incorrectly assigned the `effectiveDeployFsPath` as the `originalDeployFsPath`