### PR TITLE
Change endTime according to Ajays advice

### DIFF
--- a/src/commands/postDeploy/getLinuxDetectorError.ts
+++ b/src/commands/postDeploy/getLinuxDetectorError.ts
@@ -24,19 +24,21 @@ export enum ColumnName {
 export async function getLinuxDetectorError(context: IActionContext, detectorId: string, node: SiteTreeItem, deployResultTime: Date, siteName: string): Promise<string | undefined> {
     const detectorUri: string = `${node.id}/detectors/${detectorId}`;
     const requestOptions: requestUtils.Request = await requestUtils.getDefaultAzureRequest(detectorUri, node.root);
-    const dayAfterDeployResultTime: Date = new Date(deployResultTime.getTime() + (24 * 60 * 60 * 1000));
+    const currentTime: Date = new Date();
 
     // these parameters were specified to retrieve the timestamp from the detector by Detectors team
     // string "Latest time seen by detector. To be used in VSCode integration."" is added to response
     // when val: 'vscode' is added
+    // https://github.com/microsoft/vscode-azureappservice/issues/1235
+
     requestOptions.qs = {
         'api-version': "2015-08-01",
         fId: "1",
         btnId: "2",
         val: "vscode",
         inpId: "1",
-        startTime: deployResultTime.toISOString(),
-        endTime: dayAfterDeployResultTime.toISOString()
+        startTime: new Date(currentTime.valueOf() - 1000),
+        endTime: currentTime
     };
 
     const detectorResponse: string = await requestUtils.sendRequest<string>(requestOptions);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1235

Haven't really been able to test this since zipdeploy hasn't been working, changed the time according to these comments: https://github.com/microsoft/vscode-azureappservice/issues/1235 I get the impression that we should always make the endTime the current time to ensure that we get the latest result.

I kept the timestamp validation the same though.  The timestamp was added specifically for us to cross-reference to the latest deploy time.