### PR TITLE
Fix stale 🍞 etag 🏷️ and updating with wrong text 📜

### DIFF
--- a/src/explorer/editors/FileEditor.ts
+++ b/src/explorer/editors/FileEditor.ts
@@ -12,7 +12,7 @@ export class FileEditor extends BaseEditor<FileTreeItem> {
     private _etags: Map<string, string> = new Map<string, string>();
 
     constructor() {
-        super(`${ext.prefix}showSavePrompt`);
+        super(`${ext.prefix}.showSavePrompt`);
     }
 
     public async getSaveConfirmationText(node: FileTreeItem): Promise<string> {

--- a/src/explorer/editors/FileEditor.ts
+++ b/src/explorer/editors/FileEditor.ts
@@ -40,7 +40,7 @@ export class FileEditor extends BaseEditor<FileTreeItem> {
             await putFile(node.root.client, data, node.path, etag);
         } catch (error) {
             const parsedError: IParsedError = parseError(error);
-            if (parsedError.message === 'ETag does not represent the latest state of the resource.') {
+            if (parsedError.errorType === '412' && /etag/i.test(parsedError.message)) {
                 throw new Error(`ETag does not represent the latest state of the file "${node.label}". Download the file from Azure to get the latest version.`);
             }
             throw error;


### PR DESCRIPTION
Turns out updateData was always called with two parameters-- the text of the document itself.  So it made all that activeEditor logic unnecessary.

Fixes https://github.com/microsoft/vscode-azureappservice/issues/1154
Fixes https://github.com/microsoft/vscode-azureappservice/issues/287