### PR TITLE
Use effectiveDeployFsPath rather than workspace

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -68,15 +68,15 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | Site
 
     const isZipDeploy: boolean = siteConfig.scmType !== constants.ScmType.LocalGit && siteConfig !== constants.ScmType.GitHub;
     // only check enableScmDoBuildDuringDeploy if currentWorkspace matches the workspace being deployed as a user can "Browse" to a different project
-    if (getWorkspaceSetting<boolean>(constants.configurationSettings.showBuildDuringDeployPrompt, deployContext.workspace.uri.fsPath)) {
+    if (getWorkspaceSetting<boolean>(constants.configurationSettings.showBuildDuringDeployPrompt, deployContext.effectiveDeployFsPath)) {
         //check if node is being zipdeployed and that there is no .deployment file
-        if (siteConfig.linuxFxVersion && isZipDeploy && !(await pathExists(path.join(deployContext.workspace.uri.fsPath, constants.deploymentFileName)))) {
+        if (siteConfig.linuxFxVersion && isZipDeploy && !(await pathExists(path.join(deployContext.effectiveDeployFsPath, constants.deploymentFileName)))) {
             const linuxFxVersion: string = siteConfig.linuxFxVersion.toLowerCase();
             if (linuxFxVersion.startsWith(appservice.LinuxRuntimes.node)) {
                 // if it is node or python, prompt the user (as we can break them)
-                await node.promptScmDoBuildDeploy(deployContext.workspace.uri.fsPath, appservice.LinuxRuntimes.node, context);
+                await node.promptScmDoBuildDeploy(deployContext.effectiveDeployFsPath, appservice.LinuxRuntimes.node, context);
             } else if (linuxFxVersion.startsWith(appservice.LinuxRuntimes.python)) {
-                await node.promptScmDoBuildDeploy(deployContext.workspace.uri.fsPath, appservice.LinuxRuntimes.python, context);
+                await node.promptScmDoBuildDeploy(deployContext.effectiveDeployFsPath, appservice.LinuxRuntimes.python, context);
             }
 
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1228

We were using the old method of getting the workspace's fsPath, but because of subdeploy path settings, this could be inaccurate (and then not deployed).

Though that being said, I've been seeing the messaging `Ignoring .deployment file...` when deploying to a Linux node.js web app, so it doesn't seem like it's being respected anymore?