### PR TITLE
Use a regex for find LTS in version rather than equals operator

### DIFF
--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -54,7 +54,7 @@ function isNodeVersionSupported(nodeVersion: string): boolean {
     if (/lts/i.test(nodeVersion)) {
         const ltsVersionNumber: number = Number(nodeVersion.split('-')[0]);
         // if there is no version number, ltsVersionNumber will equal 'lts' which isNan
-        if (ltsVersionNumber < 8 && !isNaN(ltsVersionNumber)) {
+        if (!isNaN(ltsVersionNumber) && ltsVersionNumber < 8) {
             return false;
         }
 

--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -50,7 +50,7 @@ export function getRemoteDebugLanguage(siteConfig: SiteConfigResource, context: 
 
 // Remote debugging is currently only supported for Node.js >= 8.11
 function isNodeVersionSupported(nodeVersion: string): boolean {
-    // the portal's runtime includes several LTS versions i.e. (12-lts)
+    // the portal's Node runtimes includes several LTS versions i.e. (12-lts)
     if (/lts/.test(nodeVersion)) {
         return true;
     }

--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -50,8 +50,14 @@ export function getRemoteDebugLanguage(siteConfig: SiteConfigResource, context: 
 
 // Remote debugging is currently only supported for Node.js >= 8.11
 function isNodeVersionSupported(nodeVersion: string): boolean {
-    // the portal's Node runtimes includes several LTS versions i.e. (12-lts)
-    if (/lts/.test(nodeVersion)) {
+    // the portal's Node runtimes includes several LTS versions i.e. (lts, 8-lts, 12-lts)
+    if (/lts/i.test(nodeVersion)) {
+        const ltsVersionNumber: number = Number(nodeVersion.split('-')[0]);
+        // if there is no version number, ltsVersionNumber will equal 'lts' which isNan
+        if (ltsVersionNumber < 8 && !isNaN(ltsVersionNumber)) {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -50,8 +50,8 @@ export function getRemoteDebugLanguage(siteConfig: SiteConfigResource, context: 
 
 // Remote debugging is currently only supported for Node.js >= 8.11
 function isNodeVersionSupported(nodeVersion: string): boolean {
-    // the portal's new default node runtime is LTS
-    if (nodeVersion.toLocaleLowerCase() === 'lts') {
+    // the portal's runtime includes several LTS versions i.e. (12-lts)
+    if (/lts/.test(nodeVersion)) {
         return true;
     }
 

--- a/test/remoteDebug/getRemoteDebugLanguage.test.ts
+++ b/test/remoteDebug/getRemoteDebugLanguage.test.ts
@@ -40,6 +40,7 @@ suite('getRemoteDebugLanguage', () => {
         assert.throws(() => { getRemoteDebugLanguage({ linuxFxVersion: 'node|not.number' }, context); }, Error);
         assert.throws(() => { getRemoteDebugLanguage({ linuxFxVersion: 'NODE|6.12' }, context); }, Error);
         assert.throws(() => { getRemoteDebugLanguage({ linuxFxVersion: 'node|8.10' }, context); }, Error);
+        assert.throws(() => { getRemoteDebugLanguage({ linuxFxVersion: 'node|6-lts' }, context); }, Error);
     });
 
     test('Returns language for good versions', async () => {
@@ -50,6 +51,9 @@ suite('getRemoteDebugLanguage', () => {
         assert.equal(getRemoteDebugLanguage({ linuxFxVersion: 'NODE|8.12' }, context), RemoteDebugLanguage.Node);
         assert.equal(getRemoteDebugLanguage({ linuxFxVersion: 'node|9.0' }, context), RemoteDebugLanguage.Node);
         assert.equal(getRemoteDebugLanguage({ linuxFxVersion: 'NODE|10.11' }, context), RemoteDebugLanguage.Node);
+        assert.equal(getRemoteDebugLanguage({ linuxFxVersion: 'NODE|lts' }, context), RemoteDebugLanguage.Node);
+        assert.equal(getRemoteDebugLanguage({ linuxFxVersion: 'node|8-lts' }, context), RemoteDebugLanguage.Node);
+        assert.equal(getRemoteDebugLanguage({ linuxFxVersion: 'node|12-lts' }, context), RemoteDebugLanguage.Node);
     });
 
     test('Respects the python remote debugging experimental flag', async () => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/1298

Back when we implemented this, there was only Node LTS.  Since then, the runtime team has added Node 12 LTS, Node 8 LTS, etc.