### PR TITLE
Fix issue where deploy confirmation doesn't show

### DIFF
--- a/src/commands/createWebApp/showCreatedWebAppMessage.ts
+++ b/src/commands/createWebApp/showCreatedWebAppMessage.ts
@@ -23,7 +23,7 @@ export function showCreatedWebAppMessage(node: SiteTreeItem): void {
             if (result === AppServiceDialogResponses.viewOutput) {
                 ext.outputChannel.show();
             } else if (result === AppServiceDialogResponses.deploy) {
-                await deploy(context, node, true);
+                await deploy(context, node, [], true);
             }
         });
     });

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -26,7 +26,7 @@ import { showDeployCompletedMessage } from './showDeployCompletedMessage';
 
 const postDeployCancelTokens: Map<string, vscode.CancellationTokenSource> = new Map();
 
-export async function deploy(context: IActionContext, target?: vscode.Uri | SiteTreeItem | undefined, isTargetNewWebApp: boolean = false): Promise<void> {
+export async function deploy(context: IActionContext, target?: vscode.Uri | SiteTreeItem, _multiTargets?: (vscode.Uri | SiteTreeItem)[], isTargetNewWebApp: boolean = false): Promise<void> {
     let webAppSource: WebAppSource | undefined;
     context.telemetry.properties.deployedWithConfigs = 'false';
     let siteConfig: WebSiteModels.SiteConfigResource | undefined;


### PR DESCRIPTION
Repro steps:
1. Open a simple node.js app
1. Right click in the file explorer -> Deploy to Web App

Expected:
It asks for confirmation before deploying

Actual:
It deploys without confirmation.

This is because the third parameter of a command is an array for the case when a user selects multiple folders at once and `isTargetNewWebApp` is set to an array (aka a truth-y value). Fix is just to ignore this parameter since we only support one folder at a time.