### PR TITLE
Exclude test apps from being displayed in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,9 @@
     "editor.formatOnSave": true,
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
+    "files.exclude": {
+        "test/nightly/testFolder/*hello-world": true
+    },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
     "search.exclude": {

--- a/test/nightly/testFolder/README.md
+++ b/test/nightly/testFolder/README.md
@@ -1,0 +1,3 @@
+The test apps in this folder are excluded from being displayed in VS Code because they automatically activate their respective language extension (C#, Python, etc.) and that can get annoying for our day-to-day development.
+
+If you want to show them, you can temporarily modify the "files.exclude" pattern in `.vscode/settings.json` at the root of this repo.


### PR DESCRIPTION
These errors were showing up for me and I want to hide them:
<img width="655" alt="Screen Shot 2020-04-09 at 11 36 22 AM" src="https://user-images.githubusercontent.com/11282622/78930527-2171b700-7a59-11ea-96b5-7abb95dd8d32.png">

cc @v-wuzhai 