### PR TITLE
Update Werkzeug to 1.0.1 for python test project

### DIFF
--- a/test/nightly/testFolder/python-docs-hello-world/requirements.txt
+++ b/test/nightly/testFolder/python-docs-hello-world/requirements.txt
@@ -3,4 +3,4 @@ Flask==1.0.2
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
-Werkzeug==0.14.1
+Werkzeug==1.0.1


### PR DESCRIPTION
Instead of 0.15.3 like in [this PR](https://github.com/microsoft/vscode-azureappservice/pull/1481) which fails the Python 3.8 test on all OS's. I did a [nightly test run](https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=17825&view=results) and it just had one failure for 3.6 on linux, but since it worked on other OS's I'm guessing that was just an intermittent failure. 

