### PR TITLE
Implement getResourceName to enable more verbose logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8417,6 +8417,26 @@
                 "vscode-azurekudu": "^0.1.9",
                 "vscode-nls": "^4.1.1",
                 "websocket": "^1.0.31"
+            },
+            "dependencies": {
+                "vscode-azureextensionui": {
+                    "version": "0.31.2",
+                    "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.31.2.tgz",
+                    "integrity": "sha512-ISkDtQhsYoP6jU/36/96knsGB7hZYy2drQWEkXg4+S+PN0AcInEYalgOZuIgT6AAMIzDMcu/Bkpxxbj/lqgnhA==",
+                    "requires": {
+                        "azure-arm-resource": "^3.0.0-preview",
+                        "azure-arm-storage": "^3.1.0",
+                        "escape-string-regexp": "^2.0.0",
+                        "fs-extra": "^8.0.0",
+                        "html-to-text": "^5.1.1",
+                        "ms-rest": "^2.5.3",
+                        "ms-rest-azure": "^2.6.0",
+                        "opn": "^6.0.0",
+                        "semver": "^5.7.1",
+                        "vscode-extension-telemetry": "^0.1.5",
+                        "vscode-nls": "^4.1.1"
+                    }
+                }
             }
         },
         "vscode-azureextensiondev": {
@@ -8512,9 +8532,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.31.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.31.1.tgz",
-            "integrity": "sha512-g2xy+kKEK8YMWyJncfueiEFut+m27mkMaEdI/0z7amSYFXa/pO2g0h9bkkeoMWXO0fAEjF9gF8nvWnga4XP3TA==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.32.0.tgz",
+            "integrity": "sha512-uExtFiyf4G/+BSHG2QTIIJjcOCQSlAp6707Vp8f0ySV/q/2bcczAFyyz28yZGC3wjCkUJcx4DHfOw88Iel+RXw==",
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -828,7 +828,7 @@
         "portfinder": "^1.0.25",
         "request-promise": "^4.2.5",
         "vscode-azureappservice": "^0.58.0",
-        "vscode-azureextensionui": "^0.31.1",
+        "vscode-azureextensionui": "^0.32.0",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.1.1"
     },

--- a/src/explorer/editors/FileEditor.ts
+++ b/src/explorer/editors/FileEditor.ts
@@ -23,6 +23,10 @@ export class FileEditor extends BaseEditor<FileTreeItem> {
         return node.label;
     }
 
+    public async getResourceName(node: FileTreeItem): Promise<string> {
+        return node.root.client.fullName;
+    }
+
     public async getData(node: FileTreeItem): Promise<string> {
         const result: IFileResult = await getFile(node.root.client, node.path);
         this._etags.set(node.fullId, result.etag);


### PR DESCRIPTION
Related to PR: [vscode-azuretools#701](https://github.com/microsoft/vscode-azuretools/pull/701)

- Implement getResourceName so the resource name can be included in logs.
- Bumped the version of the shared UI package to 0.32.0.