### PR TITLE
Fix deploySubpath getting reset after "Always deploy workspace...?"

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -82,7 +82,7 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | Site
     }
 
     // tslint:disable-next-line:no-floating-promises
-    node.promptToSaveDeployDefaults(deployContext, deployContext.workspace.uri.fsPath, deployContext.originalDeployFsPath);
+    node.promptToSaveDeployDefaults(deployContext, deployContext.workspace.uri.fsPath, deployContext.effectiveDeployFsPath);
     await appservice.runPreDeployTask(deployContext, deployContext.originalDeployFsPath, siteConfig.scmType);
 
     // cancellation moved to after prompts while gathering telemetry


### PR DESCRIPTION
If a user has deploySubpath set and says yes to the question "Always deploy the workspace...?" it will set deploySubpath to an empty string. This line needs to be using the effective deploy path, not the original one:
https://github.com/microsoft/vscode-azureappservice/blob/d6fbafdb8c8aac22c3310ec25f932fe62894db99/src/explorer/SiteTreeItem.ts#L192

Fixes https://github.com/microsoft/vscode-azureappservice/issues/1246