### PR TITLE
Add logs and files nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -625,6 +625,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
             "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+            "dev": true,
             "requires": {
                 "archiver-utils": "^2.1.0",
                 "async": "^2.6.3",
@@ -639,6 +640,7 @@
                     "version": "2.6.3",
                     "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
                     "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
                     "requires": {
                         "lodash": "^4.17.14"
                     }
@@ -1739,6 +1741,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
             "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+            "dev": true,
             "requires": {
                 "buffer-crc32": "^0.2.13",
                 "crc32-stream": "^3.0.1",
@@ -1750,6 +1753,7 @@
                     "version": "2.3.7",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -1763,7 +1767,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 }
             }
         },
@@ -4362,9 +4367,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz",
-            "integrity": "sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA=="
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
         },
         "import-local": {
             "version": "2.0.0",
@@ -8393,11 +8398,11 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.61.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.61.0.tgz",
-            "integrity": "sha512-N5uCmj8Rx9feW9u7K/lcVSoVmVwDRztRfkd6wsSIFFlOBo2bhaUIEhXOB48ozsuoP2qJBYb3b7jh43s/uRGpVg==",
+            "version": "0.61.2",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.61.2.tgz",
+            "integrity": "sha512-9pXForOJ6yTXhMUroqtp3KSLn8KauPxAycUBibQBK/li6o+D2/iyJiRm3gl62AkXJSBA2M+EX6WL0YxzstTcSA==",
             "requires": {
-                "archiver": "^3.1.1",
+                "archiver": "^4.0.1",
                 "azure-arm-appinsights": "^2.1.0",
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",
@@ -8417,6 +8422,72 @@
                 "vscode-azurekudu": "^0.1.9",
                 "vscode-nls": "^4.1.1",
                 "websocket": "^1.0.31"
+            },
+            "dependencies": {
+                "archiver": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/archiver/-/archiver-4.0.1.tgz",
+                    "integrity": "sha512-/YV1pU4Nhpf/rJArM23W6GTUjT0l++VbjykrCRua1TSXrn+yM8Qs7XvtwSiRse0iCe49EPNf7ktXnPsWuSb91Q==",
+                    "requires": {
+                        "archiver-utils": "^2.1.0",
+                        "async": "^2.6.3",
+                        "buffer-crc32": "^0.2.1",
+                        "glob": "^7.1.6",
+                        "readable-stream": "^3.6.0",
+                        "tar-stream": "^2.1.2",
+                        "zip-stream": "^3.0.1"
+                    }
+                },
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                },
+                "compress-commons": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-3.0.0.tgz",
+                    "integrity": "sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==",
+                    "requires": {
+                        "buffer-crc32": "^0.2.13",
+                        "crc32-stream": "^3.0.1",
+                        "normalize-path": "^3.0.0",
+                        "readable-stream": "^2.3.7"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.7",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        }
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "zip-stream": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-3.0.1.tgz",
+                    "integrity": "sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==",
+                    "requires": {
+                        "archiver-utils": "^2.1.0",
+                        "compress-commons": "^3.0.0",
+                        "readable-stream": "^3.6.0"
+                    }
+                }
             }
         },
         "vscode-azureextensiondev": {
@@ -9419,6 +9490,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
             "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
+            "dev": true,
             "requires": {
                 "archiver-utils": "^2.1.0",
                 "compress-commons": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -853,7 +853,7 @@
         "moment": "^2.24.0",
         "portfinder": "^1.0.25",
         "request-promise": "^4.2.5",
-        "vscode-azureappservice": "^0.61.0",
+        "vscode-azureappservice": "^0.61.2",
         "vscode-azureextensionui": "^0.33.1",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.1.1"

--- a/src/commands/logstream/enableFileLogging.ts
+++ b/src/commands/logstream/enableFileLogging.ts
@@ -32,20 +32,20 @@ export async function enableFileLogging(context: IEnableFileLoggingContext, node
         return await siteNode.isHttpLogsEnabled();
     });
 
-    if (!isEnabled && siteNode instanceof SiteTreeItem && node instanceof SiteTreeItem) {
-        await ext.ui.showWarningMessage(`Do you want to enable file logging for ${node.root.client.fullName}? The web app will be restarted.`, { modal: true }, DialogResponses.yes);
-        const enablingLogging: string = `Enabling Logging for "${node.root.client.fullName}"...`;
-        const enabledLogging: string = `Enabled Logging for "${node.root.client.fullName}".`;
+    if (!isEnabled && siteNode instanceof SiteTreeItem) {
+        await ext.ui.showWarningMessage(`Do you want to enable file logging for ${siteNode.root.client.fullName}? The web app will be restarted.`, { modal: true }, DialogResponses.yes);
+        const enablingLogging: string = `Enabling Logging for "${siteNode.root.client.fullName}"...`;
+        const enabledLogging: string = `Enabled Logging for "${siteNode.root.client.fullName}".`;
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: enablingLogging }, async (): Promise<void> => {
             ext.outputChannel.appendLog(enablingLogging);
             await siteNode.enableHttpLogs();
 
-            await vscode.commands.executeCommand('appService.Restart', node);
+            await vscode.commands.executeCommand('appService.Restart', siteNode);
             vscode.window.showInformationMessage(enabledLogging);
             ext.outputChannel.appendLog(enabledLogging);
         });
     } else if (!context.suppressAlreadyEnabledMessage) {
-        const fullName: string = (node instanceof TrialAppTreeItem) ? node.client.fullName : node.root.client.fullName;
+        const fullName: string = (siteNode instanceof TrialAppTreeItem) ? siteNode.client.fullName : siteNode.root.client.fullName;
         vscode.window.showInformationMessage(`File logging has already been enabled for ${fullName}.`);
     }
 }

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -4,20 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as appservice from 'vscode-azureappservice';
+import { IFilesClient } from 'vscode-azureappservice';
 import { IActionContext } from 'vscode-azureextensionui';
-import { SiteTreeItem } from "../../explorer/SiteTreeItem";
+import { SiteTreeItem } from '../../explorer/SiteTreeItem';
+import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { WebAppTreeItem } from '../../explorer/WebAppTreeItem';
 import { ext } from '../../extensionVariables';
 import { enableFileLogging } from './enableFileLogging';
 
-export async function startStreamingLogs(context: IActionContext, node?: SiteTreeItem): Promise<void> {
+export async function startStreamingLogs(context: IActionContext, node?: SiteTreeItem | TrialAppTreeItem): Promise<void> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<WebAppTreeItem>(WebAppTreeItem.contextValue, context);
     }
 
     const verifyLoggingEnabled: () => Promise<void> = async (): Promise<void> => {
-        await enableFileLogging({ ...context, suppressAlreadyEnabledMessage: true }, node);
+        if (node instanceof TrialAppTreeItem) {
+            await enableFileLogging({ ...context, suppressAlreadyEnabledMessage: true }, node.logFilesNode);
+        } else {
+            await enableFileLogging({ ...context, suppressAlreadyEnabledMessage: true }, node);
+        }
     };
 
-    await appservice.startStreamingLogs(node.root.client, verifyLoggingEnabled, node.logStreamLabel);
+    const client: IFilesClient = (node instanceof TrialAppTreeItem) ? node.client : node.root.client;
+    await appservice.startStreamingLogs(client, verifyLoggingEnabled, node.logStreamLabel);
 }

--- a/src/explorer/trialApp/TrialAppClient.ts
+++ b/src/explorer/trialApp/TrialAppClient.ts
@@ -15,11 +15,11 @@ export class TrialAppClient implements IFilesClient {
     public isFunctionApp: boolean = false;
     public metadata: ITrialAppMetadata;
 
-    private credentials: ServiceClientCredentials;
+    private _credentials: ServiceClientCredentials;
 
     private constructor(metadata: ITrialAppMetadata) {
         this.metadata = metadata;
-        this.credentials = new BasicAuthenticationCredentials(metadata.publishingUserName, metadata.publishingPassword);
+        this._credentials = new BasicAuthenticationCredentials(metadata.publishingUserName, metadata.publishingPassword);
     }
 
     public static async createTrialAppClient(loginSession: string): Promise<TrialAppClient> {
@@ -60,7 +60,7 @@ export class TrialAppClient implements IFilesClient {
     }
 
     public async getKuduClient(): Promise<KuduClient> {
-        const kuduClient: KuduClient = new KuduClient(this.credentials, this.kuduUrl);
+        const kuduClient: KuduClient = new KuduClient(this._credentials, this.kuduUrl);
         addExtensionUserAgent(kuduClient);
         return kuduClient;
     }

--- a/src/explorer/trialApp/TrialAppClient.ts
+++ b/src/explorer/trialApp/TrialAppClient.ts
@@ -23,7 +23,19 @@ export class TrialAppClient implements IFilesClient {
     }
 
     public static async createTrialAppClient(loginSession: string): Promise<TrialAppClient> {
-        const metadata: ITrialAppMetadata = await this.getTrialAppMetaData(loginSession);
+        const metadataRequest: requestUtils.Request = await requestUtils.getDefaultRequest('https://tryappservice.azure.com/api/vscoderesource', undefined, 'GET');
+
+        metadataRequest.headers = {
+            accept: "*/*",
+            "accept-language": "en-US,en;q=0.9",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-origin",
+            cookie: `loginsession=${loginSession}`
+        };
+
+        const result: string = await requestUtils.sendRequest<string>(metadataRequest);
+        const metadata: ITrialAppMetadata = <ITrialAppMetadata>JSON.parse(result);
         return new TrialAppClient(metadata);
     }
 
@@ -45,22 +57,6 @@ export class TrialAppClient implements IFilesClient {
 
     public get defaultHostUrl(): string {
         return `https://${this.metadata.hostName}`;
-    }
-
-    public static async getTrialAppMetaData(loginSession: string): Promise<ITrialAppMetadata> {
-        const metadataRequest: requestUtils.Request = await requestUtils.getDefaultRequest('https://tryappservice.azure.com/api/vscoderesource', undefined, 'GET');
-
-        metadataRequest.headers = {
-            accept: "*/*",
-            "accept-language": "en-US,en;q=0.9",
-            "sec-fetch-dest": "empty",
-            "sec-fetch-mode": "cors",
-            "sec-fetch-site": "same-origin",
-            cookie: `loginsession=${loginSession}`
-        };
-
-        const result: string = await requestUtils.sendRequest<string>(metadataRequest);
-        return <ITrialAppMetadata>JSON.parse(result);
     }
 
     public async getKuduClient(): Promise<KuduClient> {

--- a/src/explorer/trialApp/TrialAppClient.ts
+++ b/src/explorer/trialApp/TrialAppClient.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { BasicAuthenticationCredentials, ServiceClientCredentials } from 'ms-rest';
-import { IFilesClient, IHostKeys } from 'vscode-azureappservice';
+import { IFilesClient } from 'vscode-azureappservice';
 import { addExtensionUserAgent } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
 import { localize } from '../../localize';
@@ -62,10 +62,6 @@ export class TrialAppClient implements IFilesClient {
 
         const result: string = await requestUtils.sendRequest<string>(metadataRequest);
         return <ITrialAppMetadata>JSON.parse(result);
-    }
-
-    public async listHostKeys(): Promise<IHostKeys> {
-        throw new Error('Method not implemented.');
     }
 
     public async getKuduClient(): Promise<KuduClient> {

--- a/src/explorer/trialApp/TrialAppClient.ts
+++ b/src/explorer/trialApp/TrialAppClient.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { BasicAuthenticationCredentials, ServiceClientCredentials } from 'ms-rest';
+import { IFilesClient, IHostKeys } from 'vscode-azureappservice';
+import { addExtensionUserAgent } from 'vscode-azureextensionui';
+import KuduClient from 'vscode-azurekudu';
+import { localize } from '../../localize';
+import { requestUtils } from '../../utils/requestUtils';
+import { ITrialAppMetadata } from './ITrialAppMetadata';
+
+export class TrialAppClient implements IFilesClient {
+
+    public isFunctionApp: boolean = false;
+    public metadata: ITrialAppMetadata;
+
+    private credentials: ServiceClientCredentials;
+
+    private constructor(metadata: ITrialAppMetadata) {
+        this.metadata = metadata;
+        this.credentials = new BasicAuthenticationCredentials(metadata.publishingUserName, metadata.publishingPassword);
+    }
+
+    public static async createTrialAppClient(loginSession: string): Promise<TrialAppClient> {
+        const metadata: ITrialAppMetadata = await this.getTrialAppMetaData(loginSession);
+        return new TrialAppClient(metadata);
+    }
+
+    public get fullName(): string {
+        return this.metadata.hostName;
+    }
+
+    public get id(): string {
+        return this.metadata.siteGuid;
+    }
+
+    public get kuduUrl(): string | undefined {
+        return `https://${this.metadata.scmHostName}`;
+    }
+
+    public get defaultHostName(): string {
+        return this.metadata.hostName;
+    }
+
+    public get defaultHostUrl(): string {
+        return `https://${this.metadata.hostName}`;
+    }
+
+    public static async getTrialAppMetaData(loginSession: string): Promise<ITrialAppMetadata> {
+        const metadataRequest: requestUtils.Request = await requestUtils.getDefaultRequest('https://tryappservice.azure.com/api/vscoderesource', undefined, 'GET');
+
+        metadataRequest.headers = {
+            accept: "*/*",
+            "accept-language": "en-US,en;q=0.9",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-origin",
+            cookie: `loginsession=${loginSession}`
+        };
+
+        const result: string = await requestUtils.sendRequest<string>(metadataRequest);
+        return <ITrialAppMetadata>JSON.parse(result);
+    }
+
+    public async listHostKeys(): Promise<IHostKeys> {
+        throw new Error('Method not implemented.');
+    }
+
+    public async getKuduClient(): Promise<KuduClient> {
+        if (!this.metadata.scmHostName) {
+            throw new Error(localize('notSupportedLinux', 'This operation is not supported by this app service plan.'));
+        }
+
+        const kuduClient: KuduClient = new KuduClient(this.credentials, `https://${this.metadata.scmHostName}`);
+        addExtensionUserAgent(kuduClient);
+        return kuduClient;
+    }
+}

--- a/src/explorer/trialApp/TrialAppClient.ts
+++ b/src/explorer/trialApp/TrialAppClient.ts
@@ -7,7 +7,6 @@ import { BasicAuthenticationCredentials, ServiceClientCredentials } from 'ms-res
 import { IFilesClient } from 'vscode-azureappservice';
 import { addExtensionUserAgent } from 'vscode-azureextensionui';
 import KuduClient from 'vscode-azurekudu';
-import { localize } from '../../localize';
 import { requestUtils } from '../../utils/requestUtils';
 import { ITrialAppMetadata } from './ITrialAppMetadata';
 
@@ -65,11 +64,7 @@ export class TrialAppClient implements IFilesClient {
     }
 
     public async getKuduClient(): Promise<KuduClient> {
-        if (!this.metadata.scmHostName) {
-            throw new Error(localize('notSupportedLinux', 'This operation is not supported by this app service plan.'));
-        }
-
-        const kuduClient: KuduClient = new KuduClient(this.credentials, `https://${this.metadata.scmHostName}`);
+        const kuduClient: KuduClient = new KuduClient(this.credentials, this.kuduUrl);
         addExtensionUserAgent(kuduClient);
         return kuduClient;
     }

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -3,19 +3,43 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { LogFilesTreeItem, SiteFilesTreeItem } from 'vscode-azureappservice';
 import { AzExtTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { localize } from '../../localize';
 import { openUrl } from '../../utils/openUrl';
-import { requestUtils } from '../../utils/requestUtils';
 import { AzureAccountTreeItem } from '../AzureAccountTreeItem';
 import { ISiteTreeItem } from '../ISiteTreeItem';
 import { SiteTreeItemBase } from '../SiteTreeItemBase';
 import { ITrialAppMetadata } from './ITrialAppMetadata';
+import { TrialAppClient } from './TrialAppClient';
 
 export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem {
     public static contextValue: string = 'trialApp';
     public contextValue: string = TrialAppTreeItem.contextValue;
-    public metadata: ITrialAppMetadata;
+    public readonly client: TrialAppClient;
+    public logFilesNode: LogFilesTreeItem;
+
+    private readonly _siteFilesNode: SiteFilesTreeItem;
+
+    private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
+        super(parent);
+        this.client = client;
+        this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
+        this.logFilesNode = new LogFilesTreeItem(this, client);
+    }
+
+    public static async createTrialAppTreeItem(parent: AzureAccountTreeItem, loginSession: string): Promise<TrialAppTreeItem> {
+        const client: TrialAppClient = await TrialAppClient.createTrialAppClient(loginSession);
+        return new TrialAppTreeItem(parent, client);
+    }
+
+    public get logStreamLabel(): string {
+        return this.metadata.hostName;
+    }
+
+    public get metadata(): ITrialAppMetadata {
+        return this.client.metadata;
+    }
 
     public get label(): string {
         return this.metadata.siteName ? this.metadata.siteName : localize('nodeJsTrialApp', 'NodeJS Trial App');
@@ -42,33 +66,12 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
         return `https://${this.defaultHostName}`;
     }
 
-    private constructor(parent: AzureAccountTreeItem, metadata: ITrialAppMetadata) {
-        super(parent);
-        this.metadata = metadata;
+    public async isHttpLogsEnabled(): Promise<boolean> {
+        return true;
     }
 
-    public static async createTrialAppTreeItem(parent: AzureAccountTreeItem, loginSession: string): Promise<TrialAppTreeItem> {
-        const metadata: ITrialAppMetadata = await this.getTrialAppMetaData(loginSession);
-        return new TrialAppTreeItem(parent, metadata);
-    }
-
-    public static async getTrialAppMetaData(loginSession: string): Promise<ITrialAppMetadata> {
-        const metadataRequest: requestUtils.Request = await requestUtils.getDefaultRequest('https://tryappservice.azure.com/api/vscoderesource', undefined, 'GET');
-
-        metadataRequest.headers = {
-            accept: "*/*",
-            "accept-language": "en-US,en;q=0.9",
-            "sec-fetch-dest": "empty",
-            "sec-fetch-mode": "cors",
-            "sec-fetch-site": "same-origin",
-            cookie: `loginsession=${loginSession}`
-        };
-
-        const result: string = await requestUtils.sendRequest<string>(metadataRequest);
-        return <ITrialAppMetadata>JSON.parse(result);
-    }
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
-        return [];
+        return [this._siteFilesNode, this.logFilesNode];
     }
     public hasMoreChildrenImpl(): boolean {
         return false;
@@ -79,7 +82,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     }
 
     public async refreshImpl(): Promise<void> {
-        this.metadata = await TrialAppTreeItem.getTrialAppMetaData(this.metadata.loginSession);
+        this.client.metadata = await TrialAppClient.getTrialAppMetaData(this.metadata.loginSession);
     }
 
     public isAncestorOfImpl?(contextValue: string | RegExp): boolean {

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -16,7 +16,7 @@ import { TrialAppClient } from './TrialAppClient';
 export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem {
     public static contextValue: string = 'trialApp';
     public contextValue: string = TrialAppTreeItem.contextValue;
-    public readonly client: TrialAppClient;
+    public client: TrialAppClient;
     public logFilesNode: LogFilesTreeItem;
 
     private readonly _siteFilesNode: SiteFilesTreeItem;
@@ -82,7 +82,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     }
 
     public async refreshImpl(): Promise<void> {
-        this.client.metadata = await TrialAppClient.getTrialAppMetaData(this.metadata.loginSession);
+        this.client = await TrialAppClient.createTrialAppClient(this.metadata.loginSession);
     }
 
     public isAncestorOfImpl?(contextValue: string | RegExp): boolean {


### PR DESCRIPTION
Using the changes in https://github.com/microsoft/vscode-azuretools/pull/726 to add the logs node and files node as children to the trial app node.

One of the major additions here is the `TrialAppClient` which implements the `IFilesClient` to enable the files node and logs node.