### PR TITLE
Create trialAppNode public property

### DIFF
--- a/src/commands/trialApp/cloneTrialApp.ts
+++ b/src/commands/trialApp/cloneTrialApp.ts
@@ -6,7 +6,17 @@
 import { commands } from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
 
-export async function cloneTrialApp(_context: IActionContext, node: TrialAppTreeItem): Promise<void> {
-    await commands.executeCommand('git.clone', node?.metadata.gitUrl);
+export async function cloneTrialApp(_context: IActionContext, node?: TrialAppTreeItem): Promise<void> {
+    if (!node) {
+        node = ext.azureAccountTreeItem.trialAppNode;
+    }
+
+    if (node) {
+        await commands.executeCommand('git.clone', node.metadata.gitUrl);
+    } else {
+        throw Error(localize('trialAppNotFound', 'Trial app not found.'));
+    }
 }

--- a/src/explorer/AzureAccountTreeItem.ts
+++ b/src/explorer/AzureAccountTreeItem.ts
@@ -10,6 +10,9 @@ import { SubscriptionTreeItem } from './SubscriptionTreeItem';
 import { TrialAppTreeItem } from './trialApp/TrialAppTreeItem';
 
 export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
+
+    public trialAppNode: TrialAppTreeItem | undefined;
+
     public constructor(testAccount?: {}) {
         super(undefined, testAccount);
     }


### PR DESCRIPTION
This will serve a few purposes:
* Easy check to see if a trial app exists
* Easy access to trial app properties
* Commands that can't pass in the trial app (from tutorial) can check if there is a trial app (since there will only ever be one) and use that.