### PR TITLE
Make ConnectionsTreeItem generic and add to Trial apps

### DIFF
--- a/src/explorer/ConnectionsTreeItem.ts
+++ b/src/explorer/ConnectionsTreeItem.ts
@@ -3,23 +3,25 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ISiteTreeRoot } from 'vscode-azureappservice';
-import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
+import { IAppSettingsClient, ISiteTreeRoot } from 'vscode-azureappservice';
+import { AzExtParentTreeItem, AzExtTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
 import { getThemedIconPath, IThemedIconPath } from '../utils/pathUtils';
 import { CosmosDBConnection } from './CosmosDBConnection';
 import { CosmosDBTreeItem } from './CosmosDBTreeItem';
 import { SiteTreeItem } from './SiteTreeItem';
 
-export class ConnectionsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
+export class ConnectionsTreeItem extends AzExtParentTreeItem {
     public static contextValue: string = 'connections';
     public readonly contextValue: string = ConnectionsTreeItem.contextValue;
     public readonly label: string = 'Connections';
     public readonly parent: SiteTreeItem;
+    public readonly client: IAppSettingsClient;
 
     private readonly _cosmosDBNode: CosmosDBTreeItem;
 
-    constructor(parent: SiteTreeItem) {
+    constructor(parent: AzExtParentTreeItem, client: IAppSettingsClient) {
         super(parent);
+        this.client = client;
         this._cosmosDBNode = new CosmosDBTreeItem(this);
     }
 

--- a/src/explorer/CosmosDBTreeItem.ts
+++ b/src/explorer/CosmosDBTreeItem.ts
@@ -57,7 +57,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
 
         const cosmosDBApi = await this.getCosmosDBApi();
         // tslint:disable-next-line:strict-boolean-expressions
-        const appSettings = (await this.root.client.listApplicationSettings()).properties || {};
+        const appSettings = (await this.parent.client.listApplicationSettings()).properties || {};
         const connections: IDetectedConnection[] = this.detectMongoConnections(appSettings).concat(this.detectDocDBConnections(appSettings));
         const treeItems = await this.createTreeItemsWithErrorHandling(
             connections,
@@ -90,7 +90,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         if (!databaseToAdd) {
             throw new UserCancelledError();
         }
-        const appSettingsDict = await this.root.client.listApplicationSettings();
+        const appSettingsDict = await this.parent.client.listApplicationSettings();
         // tslint:disable-next-line:strict-boolean-expressions
         appSettingsDict.properties = appSettingsDict.properties || {};
 
@@ -102,7 +102,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
             appSettingsDict.properties[k] = v;
         }
 
-        await this.root.client.updateApplicationSettings(appSettingsDict);
+        await this.parent.client.updateApplicationSettings(appSettingsDict);
         await this.parent.parent.appSettingsNode.refresh();
 
         const createdDatabase = new CosmosDBConnection(this, databaseToAdd, Array.from(newAppSettings.keys()));
@@ -110,7 +110,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
 
         const ok: vscode.MessageItem = { title: 'OK' };
         const revealDatabase: vscode.MessageItem = { title: 'Reveal Database' };
-        const message: string = `Database "${createdDatabase.label}" connected to web app "${this.root.client.fullName}". Created the following application settings: "${Array.from(newAppSettings.keys()).join(', ')}".`;
+        const message: string = `Database "${createdDatabase.label}" connected to web app "${this.parent.client.fullName}". Created the following application settings: "${Array.from(newAppSettings.keys()).join(', ')}".`;
         // Don't wait
         vscode.window.showInformationMessage(message, ok, revealDatabase).then(async (result: vscode.MessageItem | undefined) => {
             if (result === revealDatabase) {
@@ -206,7 +206,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
 
         const appSettingKey: string = await ext.ui.showInputBox({
             prompt,
-            validateInput: (v: string): string | undefined => validateAppSettingKey(appSettingsDict, this.root.client, v),
+            validateInput: (v: string): string | undefined => validateAppSettingKey(appSettingsDict, this.parent.client, v),
             value: defaultKey
         });
 
@@ -223,7 +223,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
                 if (!v) {
                     return "Connection setting prefix cannot be empty.";
                 } else {
-                    return validateAppSettingKey(appSettingsDict, this.root.client, v + this._endpointSuffix) || validateAppSettingKey(appSettingsDict, this.root.client, v + this._keySuffix) || validateAppSettingKey(appSettingsDict, this.root.client, v + this._databaseSuffix);
+                    return validateAppSettingKey(appSettingsDict, this.parent.client, v + this._endpointSuffix) || validateAppSettingKey(appSettingsDict, this.parent.client, v + this._keySuffix) || validateAppSettingKey(appSettingsDict, this.parent.client, v + this._databaseSuffix);
                 }
             },
             value: defaultPrefix

--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -33,7 +33,7 @@ export abstract class SiteTreeItem extends SiteTreeItemBase implements ISiteTree
         this._state = client.initialState;
 
         this.appSettingsNode = new AppSettingsTreeItem(this, client);
-        this._connectionsNode = new ConnectionsTreeItem(this);
+        this._connectionsNode = new ConnectionsTreeItem(this, client);
         this._siteFilesNode = new SiteFilesTreeItem(this, client, false);
         this._logFilesNode = new LogFilesTreeItem(this, client);
         // Can't find actual documentation on this, but the portal claims it and this feedback suggests it's not planned https://aka.ms/AA4q5gi

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -8,6 +8,7 @@ import { AzExtTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { localize } from '../../localize';
 import { openUrl } from '../../utils/openUrl';
 import { AzureAccountTreeItem } from '../AzureAccountTreeItem';
+import { ConnectionsTreeItem } from '../ConnectionsTreeItem';
 import { ISiteTreeItem } from '../ISiteTreeItem';
 import { SiteTreeItemBase } from '../SiteTreeItemBase';
 import { ITrialAppMetadata } from './ITrialAppMetadata';
@@ -21,13 +22,15 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
 
     private readonly _appSettingsTreeItem: TrialAppApplicationSettingsTreeItem;
     private readonly _siteFilesNode: SiteFilesTreeItem;
+    private readonly _connectionsNode: ConnectionsTreeItem;
 
     private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
         super(parent);
         this.client = client;
         this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false);
         this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
-        this.logFilesNode = new LogFilesTreeItem(this, client);
+        this._connectionsNode = new ConnectionsTreeItem(this, this.client);
+        this.logFilesNode = new LogFilesTreeItem(this, this.client);
     }
 
     public static async createTrialAppTreeItem(parent: AzureAccountTreeItem, loginSession: string): Promise<TrialAppTreeItem> {
@@ -73,7 +76,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
-        return [this._appSettingsTreeItem, this._siteFilesNode, this.logFilesNode];
+        return [this._appSettingsTreeItem, this._connectionsNode, this._siteFilesNode, this.logFilesNode];
     }
     public hasMoreChildrenImpl(): boolean {
         return false;


### PR DESCRIPTION
* Change `ConnectionsTreeItem` from extending `AzureParentTreeItem<ISiteTreeRoot>` to `AzExtParentTreeItem`
* Add the connections tree item as a child of the trial app tree item.