### PR TITLE
Hide certain trial app settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8413,9 +8413,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.62.2",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.62.2.tgz",
-            "integrity": "sha512-BS6UT8w5BhXlokI4q66CMzbQVhz5VeiEXRlXsGcEkFaembIajQRWz+H80x2m5Mpq5WwYAQOK5sV6mpALGa+uqw==",
+            "version": "0.62.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.62.3.tgz",
+            "integrity": "sha512-eG598Iw4vAjIzMEaZ4seOm7Ce3I6Su3mXwaAEbBJjyEBsHOxeVGOhtOvVcjcuaWsnCopuIBQhXgH99cJec3N/A==",
             "requires": {
                 "archiver": "^4.0.1",
                 "azure-arm-appinsights": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -878,7 +878,7 @@
         "moment": "^2.24.0",
         "portfinder": "^1.0.25",
         "request-promise": "^4.2.5",
-        "vscode-azureappservice": "^0.62.2",
+        "vscode-azureappservice": "^0.62.3",
         "vscode-azureextensionui": "^0.33.7",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.1.1"

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -14,7 +14,7 @@ import { SiteTreeItemBase } from '../SiteTreeItemBase';
 import { ITrialAppMetadata } from './ITrialAppMetadata';
 import { TrialAppClient } from './TrialAppClient';
 
-const filteredSettings: string[] = [
+const settingsToHide: string[] = [
     'SCM_BUILD_ARGS',
     'SCM_COMMAND_IDLE_TIMEOUT',
     'SCM_LOGSTREAM_TIMEOUT',
@@ -43,7 +43,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
         super(parent);
         this.client = client;
-        this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, filteredSettings);
+        this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, settingsToHide);
         this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
         this._connectionsNode = new ConnectionsTreeItem(this, this.client);
         this.logFilesNode = new LogFilesTreeItem(this, this.client);

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -14,21 +14,23 @@ import { SiteTreeItemBase } from '../SiteTreeItemBase';
 import { ITrialAppMetadata } from './ITrialAppMetadata';
 import { TrialAppClient } from './TrialAppClient';
 
+const filteredSettings: string[] = [
+    'SCM_BUILD_ARGS',
+    'SCM_COMMAND_IDLE_TIMEOUT',
+    'SCM_LOGSTREAM_TIMEOUT',
+    'SCM_TRACE_LEVEL',
+    'SCM_USE_LIBGIT2SHARP_REPOSITORY',
+    'SITE_BASH_GIT_URL',
+    'SITE_GIT_URL',
+    'SITE_SITEKEY',
+    'WEBSITE_AUTH_ENABLED',
+    'WEBSITE_NODE_DEFAULT_VERSION',
+    'WEBSITE_SITE_NAME'
+];
+
 export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem {
     public static contextValue: string = 'trialApp';
-    private static _settingsToHide: string[] = [
-        'SCM_BUILD_ARGS',
-        'SCM_COMMAND_IDLE_TIMEOUT',
-        'SCM_LOGSTREAM_TIMEOUT',
-        'SCM_TRACE_LEVEL',
-        'SCM_USE_LIBGIT2SHARP_REPOSITORY',
-        'SITE_BASH_GIT_URL',
-        'SITE_GIT_URL',
-        'SITE_SITEKEY',
-        'WEBSITE_AUTH_ENABLED',
-        'WEBSITE_NODE_DEFAULT_VERSION',
-        'WEBSITE_SITE_NAME'
-    ];
+
     public contextValue: string = TrialAppTreeItem.contextValue;
     public client: TrialAppClient;
     public logFilesNode: LogFilesTreeItem;
@@ -41,7 +43,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
         super(parent);
         this.client = client;
-        this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, TrialAppTreeItem._settingsToHide);
+        this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, filteredSettings);
         this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
         this._connectionsNode = new ConnectionsTreeItem(this, this.client);
         this.logFilesNode = new LogFilesTreeItem(this, this.client);

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -16,6 +16,19 @@ import { TrialAppClient } from './TrialAppClient';
 
 export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem {
     public static contextValue: string = 'trialApp';
+    private static _settingsToHide: string[] = [
+        'SCM_BUILD_ARGS',
+        'SCM_COMMAND_IDLE_TIMEOUT',
+        'SCM_LOGSTREAM_TIMEOUT',
+        'SCM_TRACE_LEVEL',
+        'SCM_USE_LIBGIT2SHARP_REPOSITORY',
+        'SITE_BASH_GIT_URL',
+        'SITE_GIT_URL',
+        'SITE_SITEKEY',
+        'WEBSITE_AUTH_ENABLED',
+        'WEBSITE_NODE_DEFAULT_VERSION',
+        'WEBSITE_SITE_NAME'
+    ];
     public contextValue: string = TrialAppTreeItem.contextValue;
     public client: TrialAppClient;
     public logFilesNode: LogFilesTreeItem;
@@ -28,7 +41,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
         super(parent);
         this.client = client;
-        this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false);
+        this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, TrialAppTreeItem._settingsToHide);
         this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
         this._connectionsNode = new ConnectionsTreeItem(this, this.client);
         this.logFilesNode = new LogFilesTreeItem(this, this.client);


### PR DESCRIPTION
Hide most of the app settings that come one trial apps that aren't useful to trial app users.

```
        'SCM_BUILD_ARGS',
        'SCM_COMMAND_IDLE_TIMEOUT',
        'SCM_LOGSTREAM_TIMEOUT',
        'SCM_TRACE_LEVEL',
        'SCM_USE_LIBGIT2SHARP_REPOSITORY',
        'SITE_BASH_GIT_URL',
        'SITE_GIT_URL',
        'SITE_SITEKEY',
        'WEBSITE_AUTH_ENABLED',
        'WEBSITE_NODE_DEFAULT_VERSION',
        'WEBSITE_SITE_NAME'
```