### PR TITLE
saveDeployDefaults before deploying Trial app

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -54,7 +54,9 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | Site
     const { node, isNewWebApp }: IDeployNode = await getDeployNode(deployContext, target, isTargetNewWebApp);
 
     if (node instanceof TrialAppTreeItem) {
-        await saveDeployDefaults(node.fullId, workspaceFolder.uri.fsPath, deployContext.effectiveDeployFsPath);
+        if (!ext.azureAccountTreeItem.isLoggedIn) {
+            await saveDeployDefaults(node.fullId, workspaceFolder.uri.fsPath, deployContext.effectiveDeployFsPath);
+        }
         await deployTrialApp(deployContext, node);
         return;
     }

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -24,7 +24,7 @@ import { deployTrialApp } from './deployTrialApp';
 import { getDeployNode, IDeployNode } from './getDeployNode';
 import { IDeployContext, WebAppSource } from './IDeployContext';
 import { promptScmDoBuildDeploy } from './promptScmDoBuildDeploy';
-import { promptToSaveDeployDefaults } from './promptToSaveDeployDefaults';
+import { promptToSaveDeployDefaults, saveDeployDefaults } from './promptToSaveDeployDefaults';
 import { setPreDeployTaskForDotnet } from './setPreDeployTaskForDotnet';
 import { showDeployCompletedMessage } from './showDeployCompletedMessage';
 
@@ -54,7 +54,9 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | Site
     const { node, isNewWebApp }: IDeployNode = await getDeployNode(deployContext, target, isTargetNewWebApp);
 
     if (node instanceof TrialAppTreeItem) {
-        return await deployTrialApp(deployContext, node);
+        await saveDeployDefaults(node.fullId, workspaceFolder.uri.fsPath, deployContext.effectiveDeployFsPath);
+        await deployTrialApp(deployContext, node);
+        return;
     }
 
     context.telemetry.properties.webAppSource = deployContext.webAppSource;

--- a/src/commands/deploy/getDeployNode.ts
+++ b/src/commands/deploy/getDeployNode.ts
@@ -26,7 +26,7 @@ export async function getDeployNode(context: IDeployContext, target: Uri | strin
     let isNewWebApp: boolean = isTargetNewWebApp;
     if (target instanceof SiteTreeItemBase) {
         node = target;
-    } else if (defaultWebAppId && defaultWebAppId !== none && !(ext.azureAccountTreeItem.trialAppNode && ext.azureAccountTreeItem.isLoggedIn)) {
+    } else if (defaultWebAppId && defaultWebAppId !== none) {
         node = await ext.tree.findTreeItem(defaultWebAppId, context); // resolves to undefined if app can't be found
         if (node) {
             context.webAppSource = WebAppSource.setting;

--- a/src/commands/deploy/getDeployNode.ts
+++ b/src/commands/deploy/getDeployNode.ts
@@ -26,7 +26,7 @@ export async function getDeployNode(context: IDeployContext, target: Uri | strin
     let isNewWebApp: boolean = isTargetNewWebApp;
     if (target instanceof SiteTreeItemBase) {
         node = target;
-    } else if (defaultWebAppId && defaultWebAppId !== none) {
+    } else if (defaultWebAppId && defaultWebAppId !== none && !(ext.azureAccountTreeItem.trialAppNode && ext.azureAccountTreeItem.isLoggedIn)) {
         node = await ext.tree.findTreeItem(defaultWebAppId, context); // resolves to undefined if app can't be found
         if (node) {
             context.webAppSource = WebAppSource.setting;

--- a/src/commands/deploy/promptToSaveDeployDefaults.ts
+++ b/src/commands/deploy/promptToSaveDeployDefaults.ts
@@ -19,10 +19,7 @@ export async function promptToSaveDeployDefaults(context: IActionContext, node: 
         const dontShowAgain: MessageItem = { title: "Don't show again" };
         const result: MessageItem = await ext.ui.showWarningMessage(saveDeploymentConfig, DialogResponses.yes, dontShowAgain, DialogResponses.skipForNow);
         if (result === DialogResponses.yes) {
-            await updateWorkspaceSetting(constants.configurationSettings.defaultWebAppToDeploy, node.fullId, deployPath);
-            // tslint:disable-next-line: strict-boolean-expressions
-            const subPath: string = path.relative(workspacePath, deployPath) || '.';
-            await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, subPath, deployPath);
+            await saveDeployDefaults(node.fullId, workspacePath, deployPath);
             context.telemetry.properties.promptToSaveDeployConfigs = 'Yes';
         } else if (result === dontShowAgain) {
             await updateWorkspaceSetting(constants.configurationSettings.defaultWebAppToDeploy, constants.none, deployPath);
@@ -33,4 +30,11 @@ export async function promptToSaveDeployDefaults(context: IActionContext, node: 
     } else {
         context.telemetry.properties.promptToSaveDeployConfigs = defaultWebAppToDeploySetting === constants.none ? constants.none : 'usesDefault';
     }
+}
+
+export async function saveDeployDefaults(nodeFullId: string, workspacePath: string, deployPath: string): Promise<void> {
+    await updateWorkspaceSetting(constants.configurationSettings.defaultWebAppToDeploy, nodeFullId, deployPath);
+    // tslint:disable-next-line: strict-boolean-expressions
+    const subPath: string = path.relative(workspacePath, deployPath) || '.';
+    await updateWorkspaceSetting(constants.configurationSettings.deploySubpath, subPath, deployPath);
 }


### PR DESCRIPTION
Extracted these changes out of #1614 

This makes it so when deploying a trial app, the user doesn't have to pick the trial app node as the deploy target.