### PR TITLE
Expired trial apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -440,7 +440,7 @@
                 },
                 {
                     "command": "appService.TransferToSubscription",
-                    "when": "view == azureAppService && viewItem == trialApp",
+                    "when": "view == azureAppService && viewItem =~ /^trialApp(|Expired)$/",
                     "group": "3_appServiceDeployCommands@1"
                 },
                 {
@@ -450,7 +450,7 @@
                 },
                 {
                     "command": "appService.RemoveTrialApp",
-                    "when": "view == azureAppService && viewItem =~ /^(trialApp|trialAppInvalid)$/",
+                    "when": "view == azureAppService && viewItem =~ /^trialApp(|Invalid|Expired)$/",
                     "group": "1_trialAppCommands@1"
                 },
                 {

--- a/src/explorer/trialApp/TrialAppClient.ts
+++ b/src/explorer/trialApp/TrialAppClient.ts
@@ -41,6 +41,10 @@ export class TrialAppClient implements ISimplifiedSiteClient {
         return new TrialAppClient(metadata);
     }
 
+    public get isExpired(): boolean {
+        return isNaN(this.metadata.timeLeft);
+    }
+
     public get fullName(): string {
         return this.metadata.siteName;
     }

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppSettingsTreeItem, DeploymentsTreeItem, LogFilesTreeItem, SiteFilesTreeItem } from 'vscode-azureappservice';
+import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
 import { AzExtTreeItem, GenericTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { localize } from '../../localize';
 import { openUrl } from '../../utils/openUrl';
@@ -31,6 +32,7 @@ const settingsToHide: string[] = [
 
 export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem {
     public static contextValue: string = 'trialApp';
+    public static contextValueExpired: string = 'trialAppExpired';
 
     public contextValue: string = TrialAppTreeItem.contextValue;
     public client: TrialAppClient;
@@ -45,6 +47,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
         super(parent);
         this.client = client;
+        this.contextValue = isNaN(this.minutesLeft) ? TrialAppTreeItem.contextValueExpired : TrialAppTreeItem.contextValue;
         this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, settingsToHide);
         this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
         this._connectionsNode = new ConnectionsTreeItem(this, this.client);
@@ -96,6 +99,9 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
+        if (isNaN(this.minutesLeft)) {
+            return [new GenericTreeItem(this, { label: 'Transfer to Subscription...', commandId: `${ext.prefix}.TransferToSubscription`, contextValue: 'transferToSubscription' })];
+        }
         return [this._tutorialNode, this._appSettingsTreeItem, this._connectionsNode, this.deploymentsNode, this._siteFilesNode, this.logFilesNode];
     }
     public hasMoreChildrenImpl(): boolean {

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -99,7 +99,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
-        if (isNaN(this.minutesLeft)) {
+        if (this.client.isExpired) {
             return [new GenericTreeItem(this, { label: 'Transfer to Subscription...', commandId: `${ext.prefix}.TransferToSubscription`, contextValue: 'transferToSubscription' })];
         }
         return [this._tutorialNode, this._appSettingsTreeItem, this._connectionsNode, this.deploymentsNode, this._siteFilesNode, this.logFilesNode];

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppSettingsTreeItem, DeploymentsTreeItem, LogFilesTreeItem, SiteFilesTreeItem } from 'vscode-azureappservice';
-import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
 import { AzExtTreeItem, GenericTreeItem, IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { openUrl } from '../../utils/openUrl';
 import { getThemedIconPath } from '../../utils/pathUtils';
@@ -100,7 +100,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
         if (this.client.isExpired) {
-            return [new GenericTreeItem(this, { label: 'Transfer to Subscription...', commandId: `${ext.prefix}.TransferToSubscription`, contextValue: 'transferToSubscription' })];
+            return [new GenericTreeItem(this, { label: localize('transferToSubscription', 'Transfer to Subscription...'), commandId: `${ext.prefix}.TransferToSubscription`, contextValue: 'transferToSubscription' })];
         }
         return [this._tutorialNode, this._appSettingsTreeItem, this._connectionsNode, this.deploymentsNode, this._siteFilesNode, this.logFilesNode];
     }

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -47,7 +47,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
         super(parent);
         this.client = client;
-        this.contextValue = isNaN(this.minutesLeft) ? TrialAppTreeItem.contextValueExpired : TrialAppTreeItem.contextValue;
+        this.contextValue = this.client.isExpired ? TrialAppTreeItem.contextValueExpired : TrialAppTreeItem.contextValue;
         this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, settingsToHide);
         this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
         this._connectionsNode = new ConnectionsTreeItem(this, this.client);
@@ -78,7 +78,7 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     }
 
     public get description(): string {
-        return isNaN(this.minutesLeft) ?
+        return this.client.isExpired ?
             localize('expired', 'Expired') : `${this.minutesLeft.toFixed(0)} ${localize('minutesRemaining', 'min. remaining')}`;
     }
 


### PR DESCRIPTION
When a Trial app is expired the only child is a "Transfer to Subscription..." node.

![image](https://user-images.githubusercontent.com/12476526/86055676-0045b480-ba11-11ea-8fa4-855ec731c724.png)

And the only actions in the right click context menu are:
![image](https://user-images.githubusercontent.com/12476526/86055693-0a67b300-ba11-11ea-9291-cf27bd1b650d.png)