### PR TITLE
Delay for 15 seconds when deploying trial app

### DIFF
--- a/src/commands/deploy/deployTrialApp.ts
+++ b/src/commands/deploy/deployTrialApp.ts
@@ -18,7 +18,7 @@ export async function deployTrialApp(deployContext: IDeployContext, node: TrialA
         const title: string = localize('deploying', 'Deploying to "{0}"... Check [output window](command:{1}) for status.', node.client.fullName, `${ext.prefix}.showOutputChannel`);
         return await window.withProgress({ location: ProgressLocation.Notification, title }, async () => {
             await localGitDeploy(node.client, { fsPath: deployContext.workspace.uri.fsPath, branch: 'RELEASE', commit: commit }, deployContext);
-            // Delay for 15 seconds to make sure changes are reflected immediatley after deploy 'finishes'
+            // Delay for 15 seconds to make sure changes are reflected immediately after deploy 'finishes'
             await delay(15000);
         });
     });

--- a/src/commands/deploy/deployTrialApp.ts
+++ b/src/commands/deploy/deployTrialApp.ts
@@ -8,6 +8,7 @@ import { localGitDeploy } from 'vscode-azureappservice';
 import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { localize } from '../../localize';
+import { delay } from '../../utils/delay';
 import { IDeployContext } from './IDeployContext';
 import { showDeployCompletedMessage } from './showDeployCompletedMessage';
 
@@ -17,6 +18,8 @@ export async function deployTrialApp(deployContext: IDeployContext, node: TrialA
         const title: string = localize('deploying', 'Deploying to "{0}"... Check [output window](command:{1}) for status.', node.client.fullName, `${ext.prefix}.showOutputChannel`);
         return await window.withProgress({ location: ProgressLocation.Notification, title }, async () => {
             await localGitDeploy(node.client, { fsPath: deployContext.workspace.uri.fsPath, branch: 'RELEASE', commit: commit }, deployContext);
+            // Delay for 15 seconds to make sure changes are reflected immediatley after deploy 'finishes'
+            await delay(15000);
         });
     });
     showDeployCompletedMessage(node);


### PR DESCRIPTION
I'm not happy that delaying 5 seconds or 10 seconds wasn't enough. But I really don't want users to hit "Browse" and not see the changes they just deployed.