### PR TITLE
Add telemetry parameter to TryAppService url

### DIFF
--- a/src/commands/trialApp/createTrialApp.ts
+++ b/src/commands/trialApp/createTrialApp.ts
@@ -7,5 +7,5 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { openUrl } from '../../utils/openUrl';
 
 export async function createTrialApp(_context: IActionContext): Promise<void> {
-    await openUrl('https://code.visualstudio.com/tryappservice/');
+    await openUrl('https://code.visualstudio.com/tryappservice/?utm_source=appservice-extension');
 }


### PR DESCRIPTION
This parameter will help identify where traffic is coming from for the TryAppService site. This information is for the Try App Service team, not our own telemetry.