### PR TITLE
Better handle expired Trial apps

### DIFF
--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -5,7 +5,8 @@
 
 import { commands, ProgressLocation, window } from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
-import { TrialAppLoginSession } from '../../constants';
+import { TrialAppContext } from '../../constants';
+import { ITrialAppContext } from '../../explorer/trialApp/ITrialAppContext';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
@@ -15,7 +16,22 @@ export async function importTrialApp(_context: IActionContext, loginSession: str
     await window.withProgress({ location: ProgressLocation.Notification, cancellable: false }, async p => {
         p.report({ message: localize('importingTrialApp', 'Importing trial app...') });
         ext.azureAccountTreeItem.trialAppNode = await TrialAppTreeItem.createTrialAppTreeItem(ext.azureAccountTreeItem, loginSession);
-        ext.context.globalState.update(TrialAppLoginSession, loginSession);
+        const trialAppNode = ext.azureAccountTreeItem.trialAppNode;
+
+        if (!trialAppNode.client.metadata.timeLeft) {
+            throw new Error(localize('trialAppExpired', 'Trial app is expired. Could not import.'));
+        }
+
+        const expirationDate: Date = new Date();
+        expirationDate.setSeconds(expirationDate.getSeconds() + trialAppNode.client.metadata.timeLeft);
+
+        const trialAppContext: ITrialAppContext = {
+            name: trialAppNode.client.fullName,
+            expirationDate: expirationDate,
+            loginSession: loginSession
+        }
+
+        ext.context.globalState.update(TrialAppContext, trialAppContext);
         await commands.executeCommand('workbench.view.extension.azure');
         await ext.azureAccountTreeItem.refresh();
     });

--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -29,7 +29,7 @@ export async function importTrialApp(_context: IActionContext, loginSession: str
             name: trialAppNode.client.fullName,
             expirationDate: expirationDate,
             loginSession: loginSession
-        }
+        };
 
         ext.context.globalState.update(TrialAppContext, trialAppContext);
         await commands.executeCommand('workbench.view.extension.azure');

--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -18,7 +18,7 @@ export async function importTrialApp(_context: IActionContext, loginSession: str
         ext.azureAccountTreeItem.trialAppNode = await TrialAppTreeItem.createTrialAppTreeItem(ext.azureAccountTreeItem, loginSession);
         const trialAppNode = ext.azureAccountTreeItem.trialAppNode;
 
-        if (!trialAppNode.client.metadata.timeLeft) {
+        if (trialAppNode.client.metadata.timeLeft === undefined) {
             throw new Error(localize('trialAppExpired', 'Trial app is expired. Could not import.'));
         }
 

--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -18,13 +18,13 @@ export async function importTrialApp(_context: IActionContext, loginSession: str
         ext.azureAccountTreeItem.trialAppNode = await TrialAppTreeItem.createTrialAppTreeItem(ext.azureAccountTreeItem, loginSession);
         const trialAppNode = ext.azureAccountTreeItem.trialAppNode;
 
+        // When a trial app is expired, sometimes we can get the metadata still, if we can
+        // then we know it's expired if the timeLeft is undefined
         if (trialAppNode.client.metadata.timeLeft === undefined) {
             throw new Error(localize('trialAppExpired', 'Trial app is expired. Could not import.'));
         }
 
-        const expirationDate: Date = new Date();
-        expirationDate.setSeconds(expirationDate.getSeconds() + trialAppNode.client.metadata.timeLeft);
-
+        const expirationDate: number = Date.now() + (trialAppNode.client.metadata.timeLeft * 1000);
         const trialAppContext: ITrialAppContext = {
             name: trialAppNode.client.fullName,
             expirationDate: expirationDate,

--- a/src/commands/trialApp/removeTrialApp.ts
+++ b/src/commands/trialApp/removeTrialApp.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from 'vscode-azureextensionui';
-import { TrialAppLoginSession } from '../../constants';
+import { TrialAppContext } from '../../constants';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { ext } from '../../extensionVariables';
 
@@ -13,7 +13,7 @@ export async function removeTrialApp(context: IActionContext, node?: TrialAppTre
         node = await ext.tree.showTreeItemPicker<TrialAppTreeItem>(TrialAppTreeItem.contextValue, context);
     }
 
-    ext.context.globalState.update(TrialAppLoginSession, undefined);
+    ext.context.globalState.update(TrialAppContext, undefined);
     delete ext.azureAccountTreeItem.trialAppNode;
     await ext.tree.refresh();
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,4 +34,4 @@ export const envFileName: string = '.env';
 
 export const detectorTimestampFormat: string = 'YYYY-MM-DDTHH:mm';
 
-export const TrialAppLoginSession: string = 'TrialApp.LoginSession';
+export const TrialAppContext: string = 'TrialAppContext';

--- a/src/explorer/AzureAccountTreeItem.ts
+++ b/src/explorer/AzureAccountTreeItem.ts
@@ -75,13 +75,15 @@ export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
             return undefined;
         }
 
+        if (trialAppContext.expirationDate < Date.now()) {
+            this.trialAppNode = undefined;
+            return new ExpiredTrialAppTreeItem(this, trialAppContext.name);
+        }
+
         const ti: AzExtTreeItem[] = await this.createTreeItemsWithErrorHandling(
             [trialAppContext.loginSession],
             'trialAppInvalid',
             async (source: string): Promise<AzExtTreeItem> => {
-                if (new Date(trialAppContext.expirationDate) < new Date()) {
-                    return new ExpiredTrialAppTreeItem(this, trialAppContext.name);
-                }
                 return await TrialAppTreeItem.createTrialAppTreeItem(this, source);
             },
             (_source: unknown): string => {

--- a/src/explorer/trialApp/ExpiredTrialAppTreeItem.ts
+++ b/src/explorer/trialApp/ExpiredTrialAppTreeItem.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext } from "vscode-azureextensionui";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../localize";
+import { getIconPath } from "../../utils/pathUtils";
+
+export class ExpiredTrialAppTreeItem extends AzExtParentTreeItem {
+    public label: string;
+    public contextValue: string = 'trialAppExpired';
+
+    public description: string = 'Expired';
+
+    public isAncestorOfImpl(contextValue: string | RegExp): boolean {
+        return contextValue === this.contextValue;
+    }
+
+    public constructor(parent: AzExtParentTreeItem, name: string) {
+        super(parent);
+        this.label = name;
+        this.iconPath = getIconPath('WebApp');
+    }
+
+    public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
+        return [new GenericTreeItem(this, { label: localize('transferToSubscription', 'Transfer to Subscription...'), commandId: `${ext.prefix}.TransferToSubscription`, contextValue: 'transferToSubscription', includeInTreeItemPicker: false })];
+    }
+
+    public hasMoreChildrenImpl(): boolean {
+        return false;
+    }
+}

--- a/src/explorer/trialApp/ExpiredTrialAppTreeItem.ts
+++ b/src/explorer/trialApp/ExpiredTrialAppTreeItem.ts
@@ -11,12 +11,7 @@ import { getIconPath } from "../../utils/pathUtils";
 export class ExpiredTrialAppTreeItem extends AzExtParentTreeItem {
     public label: string;
     public contextValue: string = 'trialAppExpired';
-
     public description: string = 'Expired';
-
-    public isAncestorOfImpl(contextValue: string | RegExp): boolean {
-        return contextValue === this.contextValue;
-    }
 
     public constructor(parent: AzExtParentTreeItem, name: string) {
         super(parent);
@@ -26,6 +21,10 @@ export class ExpiredTrialAppTreeItem extends AzExtParentTreeItem {
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
         return [new GenericTreeItem(this, { label: localize('transferToSubscription', 'Transfer to Subscription...'), commandId: `${ext.prefix}.TransferToSubscription`, contextValue: 'transferToSubscription', includeInTreeItemPicker: false })];
+    }
+
+    public isAncestorOfImpl(contextValue: string | RegExp): boolean {
+        return contextValue === this.contextValue;
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/explorer/trialApp/ITrialAppContext.ts
+++ b/src/explorer/trialApp/ITrialAppContext.ts
@@ -5,6 +5,10 @@
 
 export interface ITrialAppContext {
     name: string;
-    expirationDate: Date;
+
+    /**
+     * When the trial app expires in milliseconds
+     */
+    expirationDate: number;
     loginSession: string;
 }

--- a/src/explorer/trialApp/ITrialAppContext.ts
+++ b/src/explorer/trialApp/ITrialAppContext.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+export interface ITrialAppContext {
+    name: string;
+    expirationDate: Date;
+    loginSession: string;
+}

--- a/src/explorer/trialApp/TrialAppTreeItem.ts
+++ b/src/explorer/trialApp/TrialAppTreeItem.ts
@@ -5,7 +5,6 @@
 
 import { AppSettingsTreeItem, DeploymentsTreeItem, LogFilesTreeItem, SiteFilesTreeItem } from 'vscode-azureappservice';
 import { AzExtTreeItem, GenericTreeItem, IActionContext } from 'vscode-azureextensionui';
-import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { openUrl } from '../../utils/openUrl';
 import { getThemedIconPath } from '../../utils/pathUtils';
@@ -32,7 +31,6 @@ const settingsToHide: string[] = [
 
 export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem {
     public static contextValue: string = 'trialApp';
-    public static contextValueExpired: string = 'trialAppExpired';
 
     public contextValue: string = TrialAppTreeItem.contextValue;
     public client: TrialAppClient;
@@ -47,7 +45,6 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     private constructor(parent: AzureAccountTreeItem, client: TrialAppClient) {
         super(parent);
         this.client = client;
-        this.contextValue = this.client.isExpired ? TrialAppTreeItem.contextValueExpired : TrialAppTreeItem.contextValue;
         this._appSettingsTreeItem = new TrialAppApplicationSettingsTreeItem(this, this.client, false, settingsToHide);
         this._siteFilesNode = new SiteFilesTreeItem(this, this.client, false);
         this._connectionsNode = new ConnectionsTreeItem(this, this.client);
@@ -99,9 +96,6 @@ export class TrialAppTreeItem extends SiteTreeItemBase implements ISiteTreeItem 
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
-        if (this.client.isExpired) {
-            return [new GenericTreeItem(this, { label: localize('transferToSubscription', 'Transfer to Subscription...'), commandId: `${ext.prefix}.TransferToSubscription`, contextValue: 'transferToSubscription' })];
-        }
         return [this._tutorialNode, this._appSettingsTreeItem, this._connectionsNode, this.deploymentsNode, this._siteFilesNode, this.logFilesNode];
     }
     public hasMoreChildrenImpl(): boolean {


### PR DESCRIPTION
Some edge cases that I had to handle here:

1. Importing an expired trial app
    a. If we are still able to get the trial app metadata (the timeLeft property is undefined in this case).
    b. If the request to get metadata returns an error.
2. Reloading VS Code with an expired trial app. This is why I had to add additional information to the context.globalState

Fixes #1645 