### PR TITLE
Add telemetry properties to trial app commands

### DIFF
--- a/src/commands/browseWebsite.ts
+++ b/src/commands/browseWebsite.ts
@@ -5,19 +5,16 @@
 
 import { IActionContext } from 'vscode-azureextensionui';
 import { ISiteTreeItem } from '../explorer/ISiteTreeItem';
-import { TrialAppTreeItem } from '../explorer/trialApp/TrialAppTreeItem';
 import { WebAppTreeItem } from '../explorer/WebAppTreeItem';
 import { ext } from '../extensionVariables';
+import { addTrialAppTelemetry } from './trialApp/addTrialAppTelemetry';
 
 export async function browseWebsite(context: IActionContext, node?: ISiteTreeItem): Promise<void> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<WebAppTreeItem>(WebAppTreeItem.contextValue, context);
     }
 
-    if (node instanceof TrialAppTreeItem) {
-        context.telemetry.properties.trialApp = 'true';
-        context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
-    }
+    addTrialAppTelemetry(context, node);
 
     await node.browse();
 }

--- a/src/commands/browseWebsite.ts
+++ b/src/commands/browseWebsite.ts
@@ -5,12 +5,18 @@
 
 import { IActionContext } from 'vscode-azureextensionui';
 import { ISiteTreeItem } from '../explorer/ISiteTreeItem';
+import { TrialAppTreeItem } from '../explorer/trialApp/TrialAppTreeItem';
 import { WebAppTreeItem } from '../explorer/WebAppTreeItem';
 import { ext } from '../extensionVariables';
 
 export async function browseWebsite(context: IActionContext, node?: ISiteTreeItem): Promise<void> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<WebAppTreeItem>(WebAppTreeItem.contextValue, context);
+    }
+
+    if (node instanceof TrialAppTreeItem) {
+        context.telemetry.properties.trialApp = 'true';
+        context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
     }
 
     await node.browse();

--- a/src/commands/browseWebsite.ts
+++ b/src/commands/browseWebsite.ts
@@ -16,7 +16,7 @@ export async function browseWebsite(context: IActionContext, node?: ISiteTreeIte
 
     if (node instanceof TrialAppTreeItem) {
         context.telemetry.properties.trialApp = 'true';
-        context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+        context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
     }
 
     await node.browse();

--- a/src/commands/deploy/deployTrialApp.ts
+++ b/src/commands/deploy/deployTrialApp.ts
@@ -8,15 +8,14 @@ import { IDeployContext, localGitDeploy } from 'vscode-azureappservice';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
+import { addTrialAppTelemetry } from '../trialApp/addTrialAppTelemetry';
 import { showDeployCompletedMessage } from './showDeployCompletedMessage';
 
 export async function deployTrialApp(context: IDeployContext, node: TrialAppTreeItem): Promise<void> {
     const commit: boolean = context.workspaceFolder.name === node.metadata.siteName;
 
-    context.telemetry.properties.trialApp = 'true';
-    context.telemetry.properties.loggedIn = ext.azureAccountTreeItem.isLoggedIn ? 'true' : 'false';
+    addTrialAppTelemetry(context, node);
     context.telemetry.properties.isTemplateProject = commit ? 'true' : 'false';
-    context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
 
     await node.runWithTemporaryDescription("Deploying...", async () => {
         const title: string = localize('deploying', 'Deploying to "{0}"... Check [output window](command:{1}) for status.', node.client.fullName, `${ext.prefix}.showOutputChannel`);

--- a/src/commands/deploy/deployTrialApp.ts
+++ b/src/commands/deploy/deployTrialApp.ts
@@ -16,7 +16,7 @@ export async function deployTrialApp(context: IDeployContext, node: TrialAppTree
     context.telemetry.properties.trialApp = 'true';
     context.telemetry.properties.loggedIn = ext.azureAccountTreeItem.isLoggedIn ? 'true' : 'false';
     context.telemetry.properties.commit = commit ? 'true' : 'false';
-    context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+    context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
 
     await node.runWithTemporaryDescription("Deploying...", async () => {
         const title: string = localize('deploying', 'Deploying to "{0}"... Check [output window](command:{1}) for status.', node.client.fullName, `${ext.prefix}.showOutputChannel`);

--- a/src/commands/deploy/deployTrialApp.ts
+++ b/src/commands/deploy/deployTrialApp.ts
@@ -5,15 +5,20 @@
 
 import { ProgressLocation, window } from 'vscode';
 import { IDeployContext, localGitDeploy } from 'vscode-azureappservice';
-import { ext } from 'vscode-azureappservice/out/src/extensionVariables';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
+import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { showDeployCompletedMessage } from './showDeployCompletedMessage';
 
 export async function deployTrialApp(context: IDeployContext, node: TrialAppTreeItem): Promise<void> {
+    const commit: boolean = context.workspaceFolder.name === node.metadata.siteName;
+
     context.telemetry.properties.trialApp = 'true';
+    context.telemetry.properties.loggedIn = ext.azureAccountTreeItem.isLoggedIn ? 'true' : 'false';
+    context.telemetry.properties.commit = commit ? 'true' : 'false';
+    context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+
     await node.runWithTemporaryDescription("Deploying...", async () => {
-        const commit: boolean = context.workspaceFolder.name === node.metadata.siteName;
         const title: string = localize('deploying', 'Deploying to "{0}"... Check [output window](command:{1}) for status.', node.client.fullName, `${ext.prefix}.showOutputChannel`);
         return await window.withProgress({ location: ProgressLocation.Notification, title }, async () => {
             await localGitDeploy(node.client, { fsPath: context.workspaceFolder.uri.fsPath, branch: 'RELEASE', commit: commit }, context);

--- a/src/commands/deploy/deployTrialApp.ts
+++ b/src/commands/deploy/deployTrialApp.ts
@@ -15,7 +15,7 @@ export async function deployTrialApp(context: IDeployContext, node: TrialAppTree
 
     context.telemetry.properties.trialApp = 'true';
     context.telemetry.properties.loggedIn = ext.azureAccountTreeItem.isLoggedIn ? 'true' : 'false';
-    context.telemetry.properties.commit = commit ? 'true' : 'false';
+    context.telemetry.properties.isTemplateProject = commit ? 'true' : 'false';
     context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
 
     await node.runWithTemporaryDescription("Deploying...", async () => {

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as appservice from 'vscode-azureappservice';
-import { ISimplifiedSiteClient } from 'vscode-azureappservice';
 import { IActionContext } from 'vscode-azureextensionui';
 import { SiteTreeItem } from '../../explorer/SiteTreeItem';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
@@ -25,6 +24,10 @@ export async function startStreamingLogs(context: IActionContext, node?: SiteTre
         }
     };
 
-    const client: ISimplifiedSiteClient = (node instanceof TrialAppTreeItem) ? node.client : node.root.client;
-    await appservice.startStreamingLogs(client, verifyLoggingEnabled, node.logStreamLabel);
+    if (node instanceof TrialAppTreeItem) {
+        context.telemetry.properties.trialApp = 'true';
+        context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+    }
+
+    await appservice.startStreamingLogs(node.client, verifyLoggingEnabled, node.logStreamLabel);
 }

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -24,10 +24,5 @@ export async function startStreamingLogs(context: IActionContext, node?: SiteTre
         }
     };
 
-    if (node instanceof TrialAppTreeItem) {
-        context.telemetry.properties.trialApp = 'true';
-        context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
-    }
-
     await appservice.startStreamingLogs(node.client, verifyLoggingEnabled, node.logStreamLabel);
 }

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -26,7 +26,7 @@ export async function startStreamingLogs(context: IActionContext, node?: SiteTre
 
     if (node instanceof TrialAppTreeItem) {
         context.telemetry.properties.trialApp = 'true';
-        context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+        context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
     }
 
     await appservice.startStreamingLogs(node.client, verifyLoggingEnabled, node.logStreamLabel);

--- a/src/commands/logstream/stopStreamingLogs.ts
+++ b/src/commands/logstream/stopStreamingLogs.ts
@@ -15,10 +15,5 @@ export async function stopStreamingLogs(context: IActionContext, node?: SiteTree
         node = await ext.tree.showTreeItemPicker<WebAppTreeItem>(WebAppTreeItem.contextValue, { ...context, suppressCreatePick: true });
     }
 
-    if (node instanceof TrialAppTreeItem) {
-        context.telemetry.properties.trialApp = 'true';
-        context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
-    }
-
     await appservice.stopStreamingLogs(node.client);
 }

--- a/src/commands/logstream/stopStreamingLogs.ts
+++ b/src/commands/logstream/stopStreamingLogs.ts
@@ -17,7 +17,7 @@ export async function stopStreamingLogs(context: IActionContext, node?: SiteTree
 
     if (node instanceof TrialAppTreeItem) {
         context.telemetry.properties.trialApp = 'true';
-        context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+        context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
     }
 
     await appservice.stopStreamingLogs(node.client);

--- a/src/commands/logstream/stopStreamingLogs.ts
+++ b/src/commands/logstream/stopStreamingLogs.ts
@@ -15,5 +15,10 @@ export async function stopStreamingLogs(context: IActionContext, node?: SiteTree
         node = await ext.tree.showTreeItemPicker<WebAppTreeItem>(WebAppTreeItem.contextValue, { ...context, suppressCreatePick: true });
     }
 
+    if (node instanceof TrialAppTreeItem) {
+        context.telemetry.properties.trialApp = 'true';
+        context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+    }
+
     await appservice.stopStreamingLogs(node.client);
 }

--- a/src/commands/trialApp/addTrialAppTelemetry.ts
+++ b/src/commands/trialApp/addTrialAppTelemetry.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from 'vscode-azureextensionui';
+import { ISiteTreeItem } from '../../explorer/ISiteTreeItem';
+import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
+import { ext } from '../../extensionVariables';
+
+export function addTrialAppTelemetry(context: IActionContext, node: ISiteTreeItem): void {
+    if (node instanceof TrialAppTreeItem) {
+        context.telemetry.properties.trialApp = 'true';
+        context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
+        context.telemetry.properties.loggedIn = ext.azureAccountTreeItem.isLoggedIn ? 'true' : 'false';
+    }
+}

--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -11,7 +11,7 @@ import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 
-export async function importTrialApp(_context: IActionContext, loginSession: string): Promise<void> {
+export async function importTrialApp(context: IActionContext, loginSession: string): Promise<void> {
 
     await window.withProgress({ location: ProgressLocation.Notification, cancellable: false }, async p => {
         p.report({ message: localize('importingTrialApp', 'Importing trial app...') });
@@ -30,7 +30,7 @@ export async function importTrialApp(_context: IActionContext, loginSession: str
             expirationDate: expirationDate,
             loginSession: loginSession
         };
-
+        context.telemetry.properties.timeLeft = String(trialAppNode.metadata.timeLeft);
         ext.context.globalState.update(TrialAppContext, trialAppContext);
         await commands.executeCommand('workbench.view.extension.azure');
         await ext.azureAccountTreeItem.refresh();

--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -30,7 +30,7 @@ export async function importTrialApp(context: IActionContext, loginSession: stri
             expirationDate: expirationDate,
             loginSession: loginSession
         };
-        context.telemetry.properties.timeLeft = String(trialAppNode.metadata.timeLeft);
+        context.telemetry.properties.trialTimeRemaining = String(trialAppNode.metadata.timeLeft);
         ext.context.globalState.update(TrialAppContext, trialAppContext);
         await commands.executeCommand('workbench.view.extension.azure');
         await ext.azureAccountTreeItem.refresh();

--- a/src/commands/trialApp/removeTrialApp.ts
+++ b/src/commands/trialApp/removeTrialApp.ts
@@ -9,6 +9,7 @@ import { TrialAppContext } from '../../constants';
 import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
+import { addTrialAppTelemetry } from './addTrialAppTelemetry';
 
 export async function removeTrialApp(context: IActionContext, node?: TrialAppTreeItem): Promise<void> {
     if (!node) {
@@ -19,7 +20,7 @@ export async function removeTrialApp(context: IActionContext, node?: TrialAppTre
     const remove: MessageItem = { title: 'Remove' };
     await ext.ui.showWarningMessage(message, { modal: true }, remove);
 
-    context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
+    addTrialAppTelemetry(context, node);
 
     ext.context.globalState.update(TrialAppContext, undefined);
     delete ext.azureAccountTreeItem.trialAppNode;

--- a/src/commands/trialApp/removeTrialApp.ts
+++ b/src/commands/trialApp/removeTrialApp.ts
@@ -19,7 +19,7 @@ export async function removeTrialApp(context: IActionContext, node?: TrialAppTre
     const remove: MessageItem = { title: 'Remove' };
     await ext.ui.showWarningMessage(message, { modal: true }, remove);
 
-    context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+    context.telemetry.properties.trialTimeRemaining = String(node.metadata.timeLeft);
 
     ext.context.globalState.update(TrialAppContext, undefined);
     delete ext.azureAccountTreeItem.trialAppNode;

--- a/src/commands/trialApp/removeTrialApp.ts
+++ b/src/commands/trialApp/removeTrialApp.ts
@@ -19,6 +19,8 @@ export async function removeTrialApp(context: IActionContext, node?: TrialAppTre
     const remove: MessageItem = { title: 'Remove' };
     await ext.ui.showWarningMessage(message, { modal: true }, remove);
 
+    context.telemetry.properties.timeLeft = String(node.metadata.timeLeft);
+
     ext.context.globalState.update(TrialAppContext, undefined);
     delete ext.azureAccountTreeItem.trialAppNode;
     await ext.tree.refresh();

--- a/src/commands/trialApp/showTutorial.ts
+++ b/src/commands/trialApp/showTutorial.ts
@@ -19,7 +19,7 @@ export async function showTutorial(context: IActionContext): Promise<void> {
             const tutorialUri: Uri = Uri.file(ext.context.asAbsolutePath('resources/TrialApp.didact.md'));
             commands.executeCommand('vscode.didact.startDidact', tutorialUri);
             context.telemetry.properties.installedDidact = 'true';
-            context.telemetry.properties.timeLeft = String(trialAppNode.metadata.timeLeft);
+            context.telemetry.properties.trialTimeRemaining = String(trialAppNode.metadata.timeLeft);
         }
     } else {
         throw Error(localize('trialAppNotFound', 'Trial app not found.'));

--- a/src/commands/trialApp/showTutorial.ts
+++ b/src/commands/trialApp/showTutorial.ts
@@ -19,6 +19,7 @@ export async function showTutorial(context: IActionContext): Promise<void> {
             const tutorialUri: Uri = Uri.file(ext.context.asAbsolutePath('resources/TrialApp.didact.md'));
             commands.executeCommand('vscode.didact.startDidact', tutorialUri);
             context.telemetry.properties.installedDidact = 'true';
+            context.telemetry.properties.timeLeft = String(trialAppNode.metadata.timeLeft);
         }
     } else {
         throw Error(localize('trialAppNotFound', 'Trial app not found.'));

--- a/src/commands/trialApp/transferToSubscription.ts
+++ b/src/commands/trialApp/transferToSubscription.ts
@@ -13,7 +13,7 @@ import { deploy } from '../deploy/deploy';
 
 export async function transferToSubscription(context: IActionContext): Promise<void> {
     const trialAppNode: TrialAppTreeItem | undefined = ext.azureAccountTreeItem.trialAppNode;
-    context.telemetry.properties.timeLeft = String(trialAppNode?.metadata.timeLeft);
+    context.telemetry.properties.trialTimeRemaining = String(trialAppNode?.metadata.timeLeft);
 
     const newSite: WebAppTreeItem = await createWebApp(Object.assign(context, { newSiteRuntime: 'NODE|12-lts', newSiteOS: WebsiteOS.linux, trialApp: true }), undefined, true);
     await deploy(context, newSite, undefined, true);

--- a/src/commands/trialApp/transferToSubscription.ts
+++ b/src/commands/trialApp/transferToSubscription.ts
@@ -5,11 +5,16 @@
 
 import { WebsiteOS } from 'vscode-azureappservice';
 import { IActionContext } from 'vscode-azureextensionui';
+import { TrialAppTreeItem } from '../../explorer/trialApp/TrialAppTreeItem';
 import { WebAppTreeItem } from '../../explorer/WebAppTreeItem';
+import { ext } from '../../extensionVariables';
 import { createWebApp } from '../createWebApp/createWebApp';
 import { deploy } from '../deploy/deploy';
 
 export async function transferToSubscription(context: IActionContext): Promise<void> {
+    const trialAppNode: TrialAppTreeItem | undefined = ext.azureAccountTreeItem.trialAppNode;
+    context.telemetry.properties.timeLeft = String(trialAppNode?.metadata.timeLeft);
+
     const newSite: WebAppTreeItem = await createWebApp(Object.assign(context, { newSiteRuntime: 'NODE|12-lts', newSiteOS: WebsiteOS.linux, trialApp: true }), undefined, true);
     await deploy(context, newSite, undefined, true);
 }


### PR DESCRIPTION
Examples of queries we can make from these properties:
- How many trial app users are deploying their own project vs. the template?
- How much time do users take after importing a trial app to deploy (if ever)?
- How many users are logged in when they deploy their trial app?