### PR TITLE
Replace Cosmos DB with Azure Databases

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,12 +268,12 @@
             },
             {
                 "command": "appService.InstallCosmosDBExtension",
-                "title": "Install Cosmos DB Extension",
+                "title": "Install Azure Databases Extension",
                 "category": "Azure App Service"
             },
             {
                 "command": "appService.RevealConnection",
-                "title": "Reveal in Cosmos DB Extension",
+                "title": "Reveal in Azure Databases Extension",
                 "category": "Azure App Service"
             },
             {

--- a/src/explorer/CosmosDBTreeItem.ts
+++ b/src/explorer/CosmosDBTreeItem.ts
@@ -18,7 +18,7 @@ import { CosmosDBConnection } from './CosmosDBConnection';
 export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public static contextValueInstalled: string = 'сosmosDBConnections';
     public static contextValueNotInstalled: string = 'сosmosDBNotInstalled';
-    public readonly label: string = 'Cosmos DB';
+    public readonly label: string = 'Azure Databases';
     public readonly childTypeLabel: string = 'Connection';
     public readonly parent: ConnectionsTreeItem;
     public cosmosDBExtension: vscode.Extension<AzureExtensionApiProvider | undefined> | undefined;
@@ -51,7 +51,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
             return [new GenericTreeItem(this, {
                 commandId: 'appService.InstallCosmosDBExtension',
                 contextValue: 'InstallCosmosDBExtension',
-                label: 'Install Cosmos DB Extension...'
+                label: 'Install Azure Databases Extension...'
             })];
         }
 

--- a/src/explorer/CosmosDBTreeItem.ts
+++ b/src/explorer/CosmosDBTreeItem.ts
@@ -140,7 +140,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
             }
         }
 
-        throw new Error('You must have the "Cosmos DB" extension installed to perform this operation.');
+        throw new Error('You must have the "Azure Databases" extension installed to perform this operation.');
     }
 
     private detectMongoConnections(appSettings: { [propertyName: string]: string }): IDetectedConnection[] {


### PR DESCRIPTION
Fixes #1643

Screenshot of changes:

![image](https://user-images.githubusercontent.com/12476526/86668398-72853e80-bfa7-11ea-8fde-bf058efd8a31.png)


Wondering if we should change the icon of the Azure Databases node to the Azure Databases icon (right now it's still the Cosmos icon)
