### PR TITLE
Add trial app commands to command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
             },
             {
                 "command": "appService.CloneTrialApp",
-                "title": "Clone...",
+                "title": "Clone trial app...",
                 "category": "Azure App Service"
             },
             {
@@ -98,7 +98,7 @@
             },
             {
                 "command": "appService.RemoveTrialApp",
-                "title": "Remove",
+                "title": "Remove trial app...",
                 "category": "Azure App Service"
             },
             {
@@ -347,8 +347,16 @@
         "menus": {
             "commandPalette": [
                 {
+                    "command": "appService.RemoveTrialApp",
+                    "when": "hasTrialApp"
+                },
+                {
+                    "command": "appService.CloneTrialApp",
+                    "when": "hasTrialApp && !trialAppExpired"
+                },
+                {
                     "command": "appService.TransferToSubscription",
-                    "when": "never"
+                    "when": "hasTrialApp"
                 },
                 {
                     "command": "appService.CreateTrialApp",
@@ -356,14 +364,6 @@
                 },
                 {
                     "command": "appService.ImportTrialApp",
-                    "when": "never"
-                },
-                {
-                    "command": "appService.CloneTrialApp",
-                    "when": "never"
-                },
-                {
-                    "command": "appService.RemoveTrialApp",
                     "when": "never"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
             },
             {
                 "command": "appService.CloneTrialApp",
-                "title": "Clone trial app...",
+                "title": "Clone Trial App...",
                 "category": "Azure App Service"
             },
             {
@@ -98,7 +98,7 @@
             },
             {
                 "command": "appService.RemoveTrialApp",
-                "title": "Remove trial app...",
+                "title": "Remove Trial App...",
                 "category": "Azure App Service"
             },
             {

--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -32,7 +32,6 @@ export async function importTrialApp(context: IActionContext, loginSession: stri
         };
         context.telemetry.properties.trialTimeRemaining = String(trialAppNode.metadata.timeLeft);
         ext.context.globalState.update(TrialAppContext, trialAppContext);
-        await commands.executeCommand('setContext', 'hasTrialApp', true);
         await commands.executeCommand('workbench.view.extension.azure');
         await ext.azureAccountTreeItem.refresh();
     });

--- a/src/commands/trialApp/importTrialApp.ts
+++ b/src/commands/trialApp/importTrialApp.ts
@@ -32,6 +32,7 @@ export async function importTrialApp(context: IActionContext, loginSession: stri
         };
         context.telemetry.properties.trialTimeRemaining = String(trialAppNode.metadata.timeLeft);
         ext.context.globalState.update(TrialAppContext, trialAppContext);
+        await commands.executeCommand('setContext', 'hasTrialApp', true);
         await commands.executeCommand('workbench.view.extension.azure');
         await ext.azureAccountTreeItem.refresh();
     });

--- a/src/commands/trialApp/removeTrialApp.ts
+++ b/src/commands/trialApp/removeTrialApp.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { commands, MessageItem } from 'vscode';
+import { MessageItem } from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { TrialAppContext } from '../../constants';
 import { ITrialAppContext } from '../../explorer/trialApp/ITrialAppContext';
@@ -30,7 +30,6 @@ export async function removeTrialApp(context: IActionContext, node?: TrialAppTre
         addTrialAppTelemetry(context, node);
     }
     ext.context.globalState.update(TrialAppContext, undefined);
-    await commands.executeCommand('setContext', 'hasTrialApp', false);
     delete ext.azureAccountTreeItem.trialAppNode;
     await ext.tree.refresh();
 }

--- a/src/explorer/AzureAccountTreeItem.ts
+++ b/src/explorer/AzureAccountTreeItem.ts
@@ -79,6 +79,7 @@ export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
         if (trialAppContext.expirationDate < Date.now()) {
             this.trialAppNode = undefined;
             await commands.executeCommand('setContext', 'trialAppExpired', true);
+            await commands.executeCommand('setContext', 'hasTrialApp', true);
             return new ExpiredTrialAppTreeItem(this, trialAppContext.name);
         }
 

--- a/src/explorer/AzureAccountTreeItem.ts
+++ b/src/explorer/AzureAccountTreeItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { commands } from 'vscode';
 import { AzExtTreeItem, AzureAccountTreeItemBase, GenericTreeItem, IActionContext, ISubscriptionContext } from 'vscode-azureextensionui';
 import { TrialAppContext } from '../constants';
 import { ext } from '../extensionVariables';
@@ -77,6 +78,7 @@ export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
 
         if (trialAppContext.expirationDate < Date.now()) {
             this.trialAppNode = undefined;
+            await commands.executeCommand('setContext', 'trialAppExpired', true);
             return new ExpiredTrialAppTreeItem(this, trialAppContext.name);
         }
 
@@ -84,6 +86,7 @@ export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
             [trialAppContext.loginSession],
             'trialAppInvalid',
             async (source: string): Promise<AzExtTreeItem> => {
+                await commands.executeCommand('setContext', 'hasTrialApp', true);
                 return await TrialAppTreeItem.createTrialAppTreeItem(this, source);
             },
             (_source: unknown): string => {

--- a/src/explorer/trialApp/ExpiredTrialAppTreeItem.ts
+++ b/src/explorer/trialApp/ExpiredTrialAppTreeItem.ts
@@ -9,8 +9,9 @@ import { localize } from "../../localize";
 import { getIconPath } from "../../utils/pathUtils";
 
 export class ExpiredTrialAppTreeItem extends AzExtParentTreeItem {
+    public static contextValue: string = 'trialAppExpired';
+    public contextValue: string = ExpiredTrialAppTreeItem.contextValue;
     public label: string;
-    public contextValue: string = 'trialAppExpired';
     public description: string = 'Expired';
 
     public constructor(parent: AzExtParentTreeItem, name: string) {


### PR DESCRIPTION
- Commands only show up when a trial app is in the tree
- Clone command does not show up if the trial has expired

Fixes #1642, Fixes #1660 