### PR TITLE
Reorder loadMoreChildrenImpl calls

### DIFF
--- a/src/explorer/AzureAccountTreeItem.ts
+++ b/src/explorer/AzureAccountTreeItem.ts
@@ -29,6 +29,8 @@ export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
     public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         const ti: AzExtTreeItem | undefined = this.trialAppNode ?? await this.loadTrialAppNode();
         await this.setContext(ti);
+
+        // Must be called after all other async calls to prevent getting stuck on the "Loading..." tree item.
         const children: AzExtTreeItem[] = await super.loadMoreChildrenImpl(clearCache, context);
 
         if (ti) {

--- a/src/explorer/AzureAccountTreeItem.ts
+++ b/src/explorer/AzureAccountTreeItem.ts
@@ -30,7 +30,7 @@ export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
         const ti: AzExtTreeItem | undefined = this.trialAppNode ?? await this.loadTrialAppNode();
         await this.setContext(ti);
 
-        // Must be called after all other async calls to prevent getting stuck on the "Loading..." tree item.
+        // Putting this after all other async calls to hopefully fix https://github.com/microsoft/vscode-azureappservice/issues/1600
         const children: AzExtTreeItem[] = await super.loadMoreChildrenImpl(clearCache, context);
 
         if (ti) {

--- a/src/explorer/AzureAccountTreeItem.ts
+++ b/src/explorer/AzureAccountTreeItem.ts
@@ -28,8 +28,8 @@ export class AzureAccountTreeItem extends AzureAccountTreeItemBase {
 
     public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         const ti: AzExtTreeItem | undefined = this.trialAppNode ?? await this.loadTrialAppNode();
-        const children: AzExtTreeItem[] = await super.loadMoreChildrenImpl(clearCache, context);
         await this.setContext(ti);
+        const children: AzExtTreeItem[] = await super.loadMoreChildrenImpl(clearCache, context);
 
         if (ti) {
             children.push(ti);


### PR DESCRIPTION
Fixes #1600 for me. However, I'd like some more testing because it's such a weird fix.

This fix works because I moved the `await super.loadMoreChildrenImpl(clearCache, context)` call so that's it's after all other async calls in the function.