### PR TITLE
Fix nightly deploy tests

### DIFF
--- a/test/nightly/deploy.test.ts
+++ b/test/nightly/deploy.test.ts
@@ -69,7 +69,7 @@ suite('Create Web App and deploy', async function (this: Mocha.Suite): Promise<v
         const hostUrl: string | undefined = (<WebAppTreeItem>await ext.tree.findTreeItem(<string>createdApp?.id, context)).root.client.defaultHostUrl;
         const client: ServiceClient = await createGenericClient();
         const response: HttpOperationResponse = await client.sendRequest({ method: 'GET', url: hostUrl });
-        assert.ok(response.bodyAsText?.includes('Hello World'), 'Expected response to include "Hello World"');
+        assert.strictEqual(response.bodyAsText, 'Hello World!');
     }
 });
 

--- a/test/nightly/testFolder/dotnet-hello-world/2.1/Startup.cs
+++ b/test/nightly/testFolder/dotnet-hello-world/2.1/Startup.cs
@@ -27,6 +27,7 @@ namespace dotnet
 
             app.Run(async (context) =>
             {
+                context.Response.ContentType = "text/plain";
                 await context.Response.WriteAsync("Hello World!");
             });
         }

--- a/test/nightly/testFolder/dotnet-hello-world/3.1/Startup.cs
+++ b/test/nightly/testFolder/dotnet-hello-world/3.1/Startup.cs
@@ -32,6 +32,7 @@ namespace _3._1
             {
                 endpoints.MapGet("/", async context =>
                 {
+                    context.Response.ContentType = "text/plain";
                     await context.Response.WriteAsync("Hello World!");
                 });
             });

--- a/test/nightly/testFolder/python-docs-hello-world/.gitignore
+++ b/test/nightly/testFolder/python-docs-hello-world/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv/
 
 # Spyder project settings
 .spyderproject

--- a/test/nightly/testFolder/python-docs-hello-world/README.md
+++ b/test/nightly/testFolder/python-docs-hello-world/README.md
@@ -1,6 +1,6 @@
 ---
 page_type: sample
-description: "This is a minimal sample app that demonstrates how to run a Python Flask application on Azure App Service on Linux."
+description: "A minimal sample app that can be used to demonstrate deploying Flask apps to Azure App Service on Linux."
 languages:
 - python
 products:
@@ -10,9 +10,9 @@ products:
 
 # Python Flask sample for Azure App Service (Linux)
 
-This is a minimal sample app that demonstrates how to run a Python Flask application on Azure App Service on Linux.
+This is a minimal Flask app that can be deployed to Azure App Service on Linux.
 
-For more information, please see the [Python on App Service quickstart](https://docs.microsoft.com/azure/app-service/containers/quickstart-python).
+For instructions on running and deploying the code, see [Quickstart: Create a Python app in Azure App Service on Linux](https://docs.microsoft.com/azure/app-service/quickstart-python).
 
 ## Contributing
 

--- a/test/nightly/testFolder/python-docs-hello-world/app.py
+++ b/test/nightly/testFolder/python-docs-hello-world/app.py
@@ -1,4 +1,5 @@
 from flask import Flask
+
 app = Flask(__name__)
 
 @app.route("/")

--- a/test/nightly/testFolder/python-docs-hello-world/requirements.txt
+++ b/test/nightly/testFolder/python-docs-hello-world/requirements.txt
@@ -1,6 +1,1 @@
-click==6.7
-Flask==1.0.2
-itsdangerous==0.24
-Jinja2==2.11.2
-MarkupSafe==1.0
-Werkzeug==1.0.1
+Flask>=1.0,<=1.1.2


### PR DESCRIPTION
The .NET Core tests were failing for reasons related to the recent sdk changes. The Python test has been failing for a while now, and all I did was pull in the latest from the sample repo [here](https://github.com/Azure-Samples/python-docs-hello-world)

Successful nightly run: https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=27338&view=results

Related to https://github.com/microsoft/vscode-azureappservice/issues/1761