### PR TITLE
Add 'Early Access' label to .NET 5

### DIFF
--- a/src/commands/createWebApp/stacks/models/AppStackModel.ts
+++ b/src/commands/createWebApp/stacks/models/AppStackModel.ts
@@ -45,4 +45,5 @@ export interface CommonSettings {
     endOfLifeDate?: string;
     isAutoUpdate?: boolean;
     isDefault?: boolean;
+    isEarlyAccess?: boolean;
 }


### PR DESCRIPTION
First, I had to add support for the "isEarlyAccess" flag itself in our UI
Second, I had to hard-code the flag for .NET 5 because it's not set yet (related to https://github.com/Azure/azure-functions-ux/pull/5543)