### PR TITLE
Remove early access workaround

### DIFF
--- a/src/commands/createWebApp/stacks/getStackPicks.ts
+++ b/src/commands/createWebApp/stacks/getStackPicks.ts
@@ -59,7 +59,6 @@ async function getStacks(context: IWebAppWizardContext & { _stacks?: WebAppStack
             }
         });
         context._stacks = <WebAppStack[]>result.parsedBody;
-        setNet5ToEarlyAccess(context._stacks);
     }
 
     return sortStacks(context, context._stacks);
@@ -73,18 +72,4 @@ function sortStacks(context: IWebAppWizardContext, stacks: WebAppStack[]): WebAp
         return index === -1 ? recommendedRuntimes.length : index;
     }
     return stacks.sort((s1, s2) => getPriority(s1) - getPriority(s2));
-}
-
-/**
- * Temporary workaround because v2020-10-01 of the stacks api doesn't properly list .NET 5 as early access
- */
-function setNet5ToEarlyAccess(stacks: WebAppStack[]): void {
-    const net5StackSettings: WebAppRuntimes | undefined = stacks.find(s => s.value === 'dotnet')?.majorVersions.find(mv => mv.value === '5')?.minorVersions.find(mv => mv.value === '5')?.stackSettings;
-    if (net5StackSettings) {
-        for (const settings of [net5StackSettings.linuxRuntimeSettings, net5StackSettings.windowsRuntimeSettings]) {
-            if (settings && settings.isEarlyAccess === undefined) {
-                settings.isEarlyAccess = true;
-            }
-        }
-    }
 }

--- a/src/commands/createWebApp/stacks/models/AppStackModel.ts
+++ b/src/commands/createWebApp/stacks/models/AppStackModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // Types copied from here:
-// https://github.com/Azure/azure-functions-ux/blob/fa150ffa944e93c6d08cc9798b558e7095febee3/server/src/stacks/2020-10-01/models/AppStackModel.ts
+// https://github.com/Azure/azure-functions-ux/blob/3322f0b5151bbfcf7a08f281efe678ebac643dc0/server/src/stacks/2020-10-01/models/AppStackModel.ts
 // tslint:disable: interface-name
 
 export interface AppStack<T, V> {

--- a/src/commands/createWebApp/stacks/models/WebAppStackModel.ts
+++ b/src/commands/createWebApp/stacks/models/WebAppStackModel.ts
@@ -6,7 +6,7 @@
 import { AppInsightsSettings, AppStack, CommonSettings, GitHubActionSettings } from './AppStackModel';
 
 // Types copied from here:
-// https://github.com/Azure/azure-functions-ux/blob/fa150ffa944e93c6d08cc9798b558e7095febee3/server/src/stacks/2020-10-01/models/WebAppStackModel.ts
+// https://github.com/Azure/azure-functions-ux/blob/3322f0b5151bbfcf7a08f281efe678ebac643dc0/server/src/stacks/2020-10-01/models/WebAppStackModel.ts
 // tslint:disable: interface-name
 
 export type WebAppStack = AppStack<WebAppRuntimes & JavaContainers, WebAppStackValue>;


### PR DESCRIPTION
Because it's no longer needed