### PR TITLE
Turn on all strict rules and defer to eslint for linter rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2565,7 +2565,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -3058,7 +3057,6 @@
             "dependencies": {
                 "anymatch": "^1.3.0",
                 "async-each": "^1.0.0",
-                "fsevents": "^1.0.0",
                 "glob-parent": "^2.0.0",
                 "inherits": "^2.0.1",
                 "is-binary-path": "^1.0.0",
@@ -5676,6 +5674,7 @@
         },
         "node_modules/fsevents/node_modules/abbrev": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
             "dev": true,
             "inBundle": true,
@@ -5684,6 +5683,7 @@
         },
         "node_modules/fsevents/node_modules/ansi-regex": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
             "dev": true,
             "inBundle": true,
@@ -5695,6 +5695,7 @@
         },
         "node_modules/fsevents/node_modules/aproba": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true,
             "inBundle": true,
@@ -5703,6 +5704,7 @@
         },
         "node_modules/fsevents/node_modules/are-we-there-yet": {
             "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
             "dev": true,
             "inBundle": true,
@@ -5715,6 +5717,7 @@
         },
         "node_modules/fsevents/node_modules/balanced-match": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true,
             "inBundle": true,
@@ -5723,6 +5726,7 @@
         },
         "node_modules/fsevents/node_modules/brace-expansion": {
             "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "inBundle": true,
@@ -5735,6 +5739,7 @@
         },
         "node_modules/fsevents/node_modules/chownr": {
             "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true,
             "inBundle": true,
@@ -5743,6 +5748,7 @@
         },
         "node_modules/fsevents/node_modules/code-point-at": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true,
             "inBundle": true,
@@ -5754,6 +5760,7 @@
         },
         "node_modules/fsevents/node_modules/concat-map": {
             "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true,
             "inBundle": true,
@@ -5762,6 +5769,7 @@
         },
         "node_modules/fsevents/node_modules/console-control-strings": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
             "dev": true,
             "inBundle": true,
@@ -5770,6 +5778,7 @@
         },
         "node_modules/fsevents/node_modules/core-util-is": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true,
             "inBundle": true,
@@ -5778,6 +5787,7 @@
         },
         "node_modules/fsevents/node_modules/debug": {
             "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
             "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
             "dev": true,
             "inBundle": true,
@@ -5789,6 +5799,7 @@
         },
         "node_modules/fsevents/node_modules/deep-extend": {
             "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
             "inBundle": true,
@@ -5800,6 +5811,7 @@
         },
         "node_modules/fsevents/node_modules/delegates": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
             "dev": true,
             "inBundle": true,
@@ -5808,6 +5820,7 @@
         },
         "node_modules/fsevents/node_modules/detect-libc": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
             "dev": true,
             "inBundle": true,
@@ -5822,6 +5835,7 @@
         },
         "node_modules/fsevents/node_modules/fs-minipass": {
             "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
             "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
             "dev": true,
             "inBundle": true,
@@ -5833,6 +5847,7 @@
         },
         "node_modules/fsevents/node_modules/fs.realpath": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true,
             "inBundle": true,
@@ -5841,6 +5856,7 @@
         },
         "node_modules/fsevents/node_modules/gauge": {
             "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "dev": true,
             "inBundle": true,
@@ -5859,6 +5875,7 @@
         },
         "node_modules/fsevents/node_modules/glob": {
             "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "inBundle": true,
@@ -5881,6 +5898,7 @@
         },
         "node_modules/fsevents/node_modules/has-unicode": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
             "dev": true,
             "inBundle": true,
@@ -5889,6 +5907,7 @@
         },
         "node_modules/fsevents/node_modules/iconv-lite": {
             "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "inBundle": true,
@@ -5903,6 +5922,7 @@
         },
         "node_modules/fsevents/node_modules/ignore-walk": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
             "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
             "dev": true,
             "inBundle": true,
@@ -5914,6 +5934,7 @@
         },
         "node_modules/fsevents/node_modules/inflight": {
             "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "inBundle": true,
@@ -5926,6 +5947,7 @@
         },
         "node_modules/fsevents/node_modules/inherits": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
             "inBundle": true,
@@ -5934,6 +5956,7 @@
         },
         "node_modules/fsevents/node_modules/ini": {
             "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true,
             "inBundle": true,
@@ -5945,6 +5968,7 @@
         },
         "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "inBundle": true,
@@ -5959,6 +5983,7 @@
         },
         "node_modules/fsevents/node_modules/isarray": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true,
             "inBundle": true,
@@ -5967,6 +5992,7 @@
         },
         "node_modules/fsevents/node_modules/minimatch": {
             "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "inBundle": true,
@@ -5981,6 +6007,7 @@
         },
         "node_modules/fsevents/node_modules/minimist": {
             "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true,
             "inBundle": true,
@@ -5989,6 +6016,7 @@
         },
         "node_modules/fsevents/node_modules/minipass": {
             "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
             "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
             "dev": true,
             "inBundle": true,
@@ -6001,6 +6029,7 @@
         },
         "node_modules/fsevents/node_modules/minizlib": {
             "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
             "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
             "dev": true,
             "inBundle": true,
@@ -6012,6 +6041,7 @@
         },
         "node_modules/fsevents/node_modules/mkdirp": {
             "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
             "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
             "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
             "dev": true,
@@ -6027,6 +6057,7 @@
         },
         "node_modules/fsevents/node_modules/ms": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true,
             "inBundle": true,
@@ -6035,6 +6066,7 @@
         },
         "node_modules/fsevents/node_modules/needle": {
             "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
             "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
             "dev": true,
             "inBundle": true,
@@ -6054,6 +6086,7 @@
         },
         "node_modules/fsevents/node_modules/node-pre-gyp": {
             "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
             "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
             "dev": true,
             "inBundle": true,
@@ -6077,6 +6110,7 @@
         },
         "node_modules/fsevents/node_modules/nopt": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
             "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
             "dev": true,
             "inBundle": true,
@@ -6092,6 +6126,7 @@
         },
         "node_modules/fsevents/node_modules/npm-bundled": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
             "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
             "dev": true,
             "inBundle": true,
@@ -6103,6 +6138,7 @@
         },
         "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
             "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
             "dev": true,
             "inBundle": true,
@@ -6111,6 +6147,7 @@
         },
         "node_modules/fsevents/node_modules/npm-packlist": {
             "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
             "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
             "dev": true,
             "inBundle": true,
@@ -6124,6 +6161,7 @@
         },
         "node_modules/fsevents/node_modules/npmlog": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "inBundle": true,
@@ -6138,6 +6176,7 @@
         },
         "node_modules/fsevents/node_modules/number-is-nan": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true,
             "inBundle": true,
@@ -6149,6 +6188,7 @@
         },
         "node_modules/fsevents/node_modules/object-assign": {
             "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true,
             "inBundle": true,
@@ -6160,6 +6200,7 @@
         },
         "node_modules/fsevents/node_modules/once": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "inBundle": true,
@@ -6171,6 +6212,7 @@
         },
         "node_modules/fsevents/node_modules/os-homedir": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true,
             "inBundle": true,
@@ -6182,6 +6224,7 @@
         },
         "node_modules/fsevents/node_modules/os-tmpdir": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true,
             "inBundle": true,
@@ -6193,6 +6236,7 @@
         },
         "node_modules/fsevents/node_modules/osenv": {
             "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "inBundle": true,
@@ -6205,6 +6249,7 @@
         },
         "node_modules/fsevents/node_modules/path-is-absolute": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true,
             "inBundle": true,
@@ -6216,6 +6261,7 @@
         },
         "node_modules/fsevents/node_modules/process-nextick-args": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true,
             "inBundle": true,
@@ -6224,6 +6270,7 @@
         },
         "node_modules/fsevents/node_modules/rc": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "inBundle": true,
@@ -6241,6 +6288,7 @@
         },
         "node_modules/fsevents/node_modules/readable-stream": {
             "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
             "dev": true,
             "inBundle": true,
@@ -6258,6 +6306,7 @@
         },
         "node_modules/fsevents/node_modules/rimraf": {
             "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "dev": true,
             "inBundle": true,
@@ -6272,6 +6321,7 @@
         },
         "node_modules/fsevents/node_modules/safe-buffer": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true,
             "inBundle": true,
@@ -6280,6 +6330,7 @@
         },
         "node_modules/fsevents/node_modules/safer-buffer": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
             "inBundle": true,
@@ -6288,6 +6339,7 @@
         },
         "node_modules/fsevents/node_modules/sax": {
             "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
             "dev": true,
             "inBundle": true,
@@ -6296,6 +6348,7 @@
         },
         "node_modules/fsevents/node_modules/semver": {
             "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true,
             "inBundle": true,
@@ -6307,6 +6360,7 @@
         },
         "node_modules/fsevents/node_modules/set-blocking": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true,
             "inBundle": true,
@@ -6315,6 +6369,7 @@
         },
         "node_modules/fsevents/node_modules/signal-exit": {
             "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true,
             "inBundle": true,
@@ -6323,6 +6378,7 @@
         },
         "node_modules/fsevents/node_modules/string_decoder": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "inBundle": true,
@@ -6334,6 +6390,7 @@
         },
         "node_modules/fsevents/node_modules/string-width": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "inBundle": true,
@@ -6350,6 +6407,7 @@
         },
         "node_modules/fsevents/node_modules/strip-ansi": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "inBundle": true,
@@ -6364,6 +6422,7 @@
         },
         "node_modules/fsevents/node_modules/strip-json-comments": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true,
             "inBundle": true,
@@ -6375,6 +6434,7 @@
         },
         "node_modules/fsevents/node_modules/tar": {
             "version": "4.4.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
             "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
             "dev": true,
             "inBundle": true,
@@ -6395,6 +6455,7 @@
         },
         "node_modules/fsevents/node_modules/util-deprecate": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true,
             "inBundle": true,
@@ -6403,6 +6464,7 @@
         },
         "node_modules/fsevents/node_modules/wide-align": {
             "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
             "dev": true,
             "inBundle": true,
@@ -6414,6 +6476,7 @@
         },
         "node_modules/fsevents/node_modules/wrappy": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true,
             "inBundle": true,
@@ -6422,6 +6485,7 @@
         },
         "node_modules/fsevents/node_modules/yallist": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "inBundle": true,
@@ -8558,7 +8622,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -18331,6 +18394,7 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
                     "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                     "bundled": true,
                     "dev": true,
@@ -18338,6 +18402,7 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "bundled": true,
                     "dev": true,
@@ -18345,6 +18410,7 @@
                 },
                 "aproba": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
                     "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                     "bundled": true,
                     "dev": true,
@@ -18352,6 +18418,7 @@
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
                     "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                     "bundled": true,
                     "dev": true,
@@ -18363,6 +18430,7 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                     "bundled": true,
                     "dev": true,
@@ -18370,6 +18438,7 @@
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "bundled": true,
                     "dev": true,
@@ -18381,6 +18450,7 @@
                 },
                 "chownr": {
                     "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
                     "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
                     "bundled": true,
                     "dev": true,
@@ -18388,6 +18458,7 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "bundled": true,
                     "dev": true,
@@ -18395,6 +18466,7 @@
                 },
                 "concat-map": {
                     "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "bundled": true,
                     "dev": true,
@@ -18402,6 +18474,7 @@
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                     "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                     "bundled": true,
                     "dev": true,
@@ -18409,6 +18482,7 @@
                 },
                 "core-util-is": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                     "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "bundled": true,
                     "dev": true,
@@ -18416,6 +18490,7 @@
                 },
                 "debug": {
                     "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "bundled": true,
                     "dev": true,
@@ -18426,6 +18501,7 @@
                 },
                 "deep-extend": {
                     "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
                     "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                     "bundled": true,
                     "dev": true,
@@ -18433,6 +18509,7 @@
                 },
                 "delegates": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                     "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "bundled": true,
                     "dev": true,
@@ -18440,6 +18517,7 @@
                 },
                 "detect-libc": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
                     "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                     "bundled": true,
                     "dev": true,
@@ -18447,6 +18525,7 @@
                 },
                 "fs-minipass": {
                     "version": "1.2.7",
+                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
                     "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
                     "bundled": true,
                     "dev": true,
@@ -18457,6 +18536,7 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "bundled": true,
                     "dev": true,
@@ -18464,6 +18544,7 @@
                 },
                 "gauge": {
                     "version": "2.7.4",
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                     "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "bundled": true,
                     "dev": true,
@@ -18481,6 +18562,7 @@
                 },
                 "glob": {
                     "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
                     "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
                     "bundled": true,
                     "dev": true,
@@ -18496,6 +18578,7 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
                     "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "bundled": true,
                     "dev": true,
@@ -18503,6 +18586,7 @@
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "bundled": true,
                     "dev": true,
@@ -18513,6 +18597,7 @@
                 },
                 "ignore-walk": {
                     "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
                     "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
                     "bundled": true,
                     "dev": true,
@@ -18523,6 +18608,7 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "bundled": true,
                     "dev": true,
@@ -18534,6 +18620,7 @@
                 },
                 "inherits": {
                     "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
                     "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
                     "bundled": true,
                     "dev": true,
@@ -18541,6 +18628,7 @@
                 },
                 "ini": {
                     "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
                     "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                     "bundled": true,
                     "dev": true,
@@ -18548,6 +18636,7 @@
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "bundled": true,
                     "dev": true,
@@ -18558,6 +18647,7 @@
                 },
                 "isarray": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "bundled": true,
                     "dev": true,
@@ -18565,6 +18655,7 @@
                 },
                 "minimatch": {
                     "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "bundled": true,
                     "dev": true,
@@ -18575,6 +18666,7 @@
                 },
                 "minimist": {
                     "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
                     "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "bundled": true,
                     "dev": true,
@@ -18582,6 +18674,7 @@
                 },
                 "minipass": {
                     "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
                     "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
                     "bundled": true,
                     "dev": true,
@@ -18593,6 +18686,7 @@
                 },
                 "minizlib": {
                     "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
                     "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
                     "bundled": true,
                     "dev": true,
@@ -18603,6 +18697,7 @@
                 },
                 "mkdirp": {
                     "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
                     "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
                     "bundled": true,
                     "dev": true,
@@ -18613,6 +18708,7 @@
                 },
                 "ms": {
                     "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "bundled": true,
                     "dev": true,
@@ -18620,6 +18716,7 @@
                 },
                 "needle": {
                     "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
                     "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
                     "bundled": true,
                     "dev": true,
@@ -18632,6 +18729,7 @@
                 },
                 "node-pre-gyp": {
                     "version": "0.14.0",
+                    "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
                     "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
                     "bundled": true,
                     "dev": true,
@@ -18651,6 +18749,7 @@
                 },
                 "nopt": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
                     "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
                     "bundled": true,
                     "dev": true,
@@ -18662,6 +18761,7 @@
                 },
                 "npm-bundled": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
                     "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
                     "bundled": true,
                     "dev": true,
@@ -18672,6 +18772,7 @@
                 },
                 "npm-normalize-package-bin": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
                     "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
                     "bundled": true,
                     "dev": true,
@@ -18679,6 +18780,7 @@
                 },
                 "npm-packlist": {
                     "version": "1.4.8",
+                    "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
                     "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
                     "bundled": true,
                     "dev": true,
@@ -18691,6 +18793,7 @@
                 },
                 "npmlog": {
                     "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
                     "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                     "bundled": true,
                     "dev": true,
@@ -18704,6 +18807,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "bundled": true,
                     "dev": true,
@@ -18711,6 +18815,7 @@
                 },
                 "object-assign": {
                     "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "bundled": true,
                     "dev": true,
@@ -18718,6 +18823,7 @@
                 },
                 "once": {
                     "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "bundled": true,
                     "dev": true,
@@ -18728,6 +18834,7 @@
                 },
                 "os-homedir": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "bundled": true,
                     "dev": true,
@@ -18735,6 +18842,7 @@
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                     "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "bundled": true,
                     "dev": true,
@@ -18742,6 +18850,7 @@
                 },
                 "osenv": {
                     "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
                     "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                     "bundled": true,
                     "dev": true,
@@ -18753,6 +18862,7 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "bundled": true,
                     "dev": true,
@@ -18760,6 +18870,7 @@
                 },
                 "process-nextick-args": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
                     "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
                     "bundled": true,
                     "dev": true,
@@ -18767,6 +18878,7 @@
                 },
                 "rc": {
                     "version": "1.2.8",
+                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
                     "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                     "bundled": true,
                     "dev": true,
@@ -18780,6 +18892,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
                     "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "bundled": true,
                     "dev": true,
@@ -18796,6 +18909,7 @@
                 },
                 "rimraf": {
                     "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
                     "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
                     "bundled": true,
                     "dev": true,
@@ -18806,6 +18920,7 @@
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                     "bundled": true,
                     "dev": true,
@@ -18813,6 +18928,7 @@
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                     "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                     "bundled": true,
                     "dev": true,
@@ -18820,6 +18936,7 @@
                 },
                 "sax": {
                     "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                     "bundled": true,
                     "dev": true,
@@ -18827,6 +18944,7 @@
                 },
                 "semver": {
                     "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "bundled": true,
                     "dev": true,
@@ -18834,6 +18952,7 @@
                 },
                 "set-blocking": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "bundled": true,
                     "dev": true,
@@ -18841,6 +18960,7 @@
                 },
                 "signal-exit": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "bundled": true,
                     "dev": true,
@@ -18848,6 +18968,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "bundled": true,
                     "dev": true,
@@ -18858,6 +18979,7 @@
                 },
                 "string-width": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "bundled": true,
                     "dev": true,
@@ -18870,6 +18992,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "bundled": true,
                     "dev": true,
@@ -18880,6 +19003,7 @@
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "bundled": true,
                     "dev": true,
@@ -18887,6 +19011,7 @@
                 },
                 "tar": {
                     "version": "4.4.13",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
                     "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
                     "bundled": true,
                     "dev": true,
@@ -18903,6 +19028,7 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                     "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "bundled": true,
                     "dev": true,
@@ -18910,6 +19036,7 @@
                 },
                 "wide-align": {
                     "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
                     "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                     "bundled": true,
                     "dev": true,
@@ -18920,6 +19047,7 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "bundled": true,
                     "dev": true,
@@ -18927,6 +19055,7 @@
                 },
                 "yallist": {
                     "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
                     "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
                     "bundled": true,
                     "dev": true,

--- a/src/explorer/CosmosDBConnection.ts
+++ b/src/explorer/CosmosDBConnection.ts
@@ -15,7 +15,7 @@ export class CosmosDBConnection extends AzExtTreeItem {
     public static contextValue: string = 'cosmosDBConnection';
     public readonly contextValue: string = CosmosDBConnection.contextValue;
     public readonly label: string;
-    public readonly parent: CosmosDBTreeItem;
+    public readonly parent!: CosmosDBTreeItem;
 
     constructor(parent: CosmosDBTreeItem, readonly cosmosExtensionItem: DatabaseAccountTreeItem | DatabaseTreeItem, readonly appSettingKeys: string[]) {
         super(parent);

--- a/src/explorer/CosmosDBTreeItem.ts
+++ b/src/explorer/CosmosDBTreeItem.ts
@@ -21,7 +21,7 @@ export class CosmosDBTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public static contextValueNotInstalled: string = 'сosmosDBNotInstalled';
     public readonly label: string = 'Databases';
     public readonly childTypeLabel: string = 'Connection';
-    public readonly parent: SiteTreeItem;
+    public readonly parent!: SiteTreeItem;
     public readonly client: IAppSettingsClient;
     public cosmosDBExtension: vscode.Extension<AzureExtensionApiProvider | undefined> | undefined;
 

--- a/src/explorer/DeploymentSlotTreeItem.ts
+++ b/src/explorer/DeploymentSlotTreeItem.ts
@@ -13,7 +13,7 @@ import { SiteTreeItem } from './SiteTreeItem';
 export class DeploymentSlotTreeItem extends SiteTreeItem {
     public static contextValue: string = 'deploymentSlot';
     public readonly contextValue: string = DeploymentSlotTreeItem.contextValue;
-    public readonly parent: DeploymentSlotsTreeItem;
+    public readonly parent!: DeploymentSlotsTreeItem;
 
     public constructor(parent: DeploymentSlotsTreeItem, client: SiteClient, site: WebSiteManagementModels.Site) {
         super(parent, client, site);

--- a/src/explorer/SiteTreeItem.ts
+++ b/src/explorer/SiteTreeItem.ts
@@ -17,7 +17,7 @@ import { WebJobsNATreeItem, WebJobsTreeItem } from './WebJobsTreeItem';
 export abstract class SiteTreeItem extends SiteTreeItemBase implements ISiteTreeItem {
     public readonly appSettingsNode: AppSettingsTreeItem;
     public deploymentsNode: DeploymentsTreeItem | undefined;
-    public parent: AzureParentTreeItem;
+    public parent!: AzureParentTreeItem;
     public site: WebSiteManagementModels.Site;
     private readonly _connectionsNode: CosmosDBTreeItem;
     private readonly _siteFilesNode: SiteFilesTreeItem;

--- a/src/explorer/WebAppTreeItem.ts
+++ b/src/explorer/WebAppTreeItem.ts
@@ -15,7 +15,7 @@ import { SiteTreeItem } from './SiteTreeItem';
 export class WebAppTreeItem extends SiteTreeItem {
     public static contextValue: string = ext.prefix;
     public readonly contextValue: string = WebAppTreeItem.contextValue;
-    public deploymentSlotsNode: DeploymentSlotsTreeItem | DeploymentSlotsNATreeItem;
+    public deploymentSlotsNode: DeploymentSlotsTreeItem | DeploymentSlotsNATreeItem | undefined;
 
     public get client(): SiteClient {
         return this.root.client;

--- a/src/explorer/WebJobsTreeItem.ts
+++ b/src/explorer/WebJobsTreeItem.ts
@@ -6,6 +6,7 @@
 import { ISiteTreeRoot } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem } from 'vscode-azureextensionui';
 import { localize } from '../localize';
+import { nonNullProp } from '../utils/nonNull';
 import { getThemedIconPath, IThemedIconPath } from '../utils/pathUtils';
 import { NotAvailableTreeItem } from './NotAvailableTreeItem';
 
@@ -29,8 +30,8 @@ export class WebJobsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
-        return (await this.root.client.listWebJobs()).map((job: webJob) => {
-            return new GenericTreeItem(this, { id: job.name, label: job.name, contextValue: 'webJob' });
+        return (await this.root.client.listWebJobs()).map(job => {
+            return new GenericTreeItem(this, { id: job.name, label: nonNullProp(job, 'name'), contextValue: 'webJob' });
         });
     }
 }
@@ -57,5 +58,3 @@ export class WebJobsNATreeItem extends NotAvailableTreeItem {
         return [new GenericTreeItem(this, { label: localize('webJobNA', 'WebJobs are not available for Linux Apps.'), contextValue: 'webJobNA' })];
     }
 }
-
-type webJob = { name: string, Message: string };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-'use strict';
-
 import * as vscode from 'vscode';
 import { registerAppServiceExtensionVariables } from 'vscode-azureappservice';
 import { AzExtTreeDataProvider, AzureUserInput, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, IActionContext, IAzureUserInput, registerErrorHandler, registerReportIssueCommand, registerUIExtensionVariables } from 'vscode-azureextensionui';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,7 @@
         ],
         "sourceMap": true,
         "rootDir": ".",
-        "noUnusedLocals": true,
-        "noImplicitThis": true,
-        "noImplicitReturns": true,
-        "strictNullChecks": true,
-        "noUnusedParameters": true,
+        "strict": true,
         "baseUrl": "./",
         "paths": {
             "*": [


### PR DESCRIPTION
TypeScript splits up its rules into two sets, "strict" and "linter". I think it's best we turn on all "strict" rules and defer to eslint for all linter rules.

 ### [Strict](https://www.typescriptlang.org/tsconfig#Strict_Type_Checking_Options_6173):
- alwaysStrict
- noImplicitAny
- noImplicitThis
- strictBindCallApply
- strictFunctionTypes
- strictNullChecks
- strictPropertyInitialization

If and when they add new rules, we will automatically get them when we upgrade our version of TypeScript.

### [Linter](https://www.typescriptlang.org/tsconfig#Additional_Checks_6176):
- noFallthroughCasesInSwitch
- noImplicitReturns
- noPropertyAccessFromIndexSignature
- noUncheckedIndexedAccess
- noUnusedLocals
- noUnusedParameters

"noUnusedLocals" and "noUnusedParameters" are covered by eslint. The only other one we were using before that's _not_ covered by eslint is "noImplicitReturns", but it didn't seem that useful anyways.