### PR TITLE
Update ui package to match locked appservice package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "open": "^8.0.4",
                 "portfinder": "^1.0.25",
                 "vscode-azureappservice": "^0.87.0",
-                "vscode-azureextensionui": "^0.49.1",
+                "vscode-azureextensionui": "^0.49.3",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^4.1.1"
             },
@@ -10425,54 +10425,6 @@
                 "yazl": "^2.5.1"
             }
         },
-        "node_modules/vscode-azureappservice/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/vscode-azureappservice/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/vscode-azureappservice/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
-        "node_modules/vscode-azureappservice/node_modules/vscode-azureextensionui": {
-            "version": "0.49.3",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
-            "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
-            "deprecated": "This package has been split and renamed to @microsoft/vscode-azext-utils and @microsoft/vscode-azext-azureutils, please update to the new names",
-            "dependencies": {
-                "@azure/arm-resources": "^4.0.0",
-                "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-resources-subscriptions": "^1.0.0",
-                "@azure/arm-storage": "^15.0.0",
-                "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/ms-rest-azure-env": "^2.0.0",
-                "@azure/ms-rest-js": "^2.2.1",
-                "dayjs": "^1.9.3",
-                "escape-string-regexp": "^2.0.0",
-                "html-to-text": "^5.1.1",
-                "open": "^8.0.4",
-                "semver": "^5.7.1",
-                "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.4.3",
-                "vscode-nls": "^4.1.1",
-                "vscode-tas-client": "^0.1.22"
-            }
-        },
         "node_modules/vscode-azureextensiondev": {
             "version": "0.9.6",
             "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.9.6.tgz",
@@ -10503,9 +10455,9 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.49.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
-            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
+            "version": "0.49.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
+            "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
             "deprecated": "This package has been split and renamed to @microsoft/vscode-azext-utils and @microsoft/vscode-azext-azureutils, please update to the new names",
             "dependencies": {
                 "@azure/arm-resources": "^4.0.0",
@@ -19573,46 +19525,6 @@
                 "vscode-nls": "^4.1.1",
                 "websocket": "^1.0.31",
                 "yazl": "^2.5.1"
-            },
-            "dependencies": {
-                "escape-string-regexp": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-                },
-                "vscode-azureextensionui": {
-                    "version": "0.49.3",
-                    "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
-                    "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
-                    "requires": {
-                        "@azure/arm-resources": "^4.0.0",
-                        "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                        "@azure/arm-resources-subscriptions": "^1.0.0",
-                        "@azure/arm-storage": "^15.0.0",
-                        "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                        "@azure/ms-rest-azure-env": "^2.0.0",
-                        "@azure/ms-rest-js": "^2.2.1",
-                        "dayjs": "^1.9.3",
-                        "escape-string-regexp": "^2.0.0",
-                        "html-to-text": "^5.1.1",
-                        "open": "^8.0.4",
-                        "semver": "^5.7.1",
-                        "uuid": "^8.3.2",
-                        "vscode-extension-telemetry": "^0.4.3",
-                        "vscode-nls": "^4.1.1",
-                        "vscode-tas-client": "^0.1.22"
-                    }
-                }
             }
         },
         "vscode-azureextensiondev": {
@@ -19647,9 +19559,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.49.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
-            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
+            "version": "0.49.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
+            "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
             "requires": {
                 "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -814,7 +814,7 @@
         "open": "^8.0.4",
         "portfinder": "^1.0.25",
         "vscode-azureappservice": "^0.87.0",
-        "vscode-azureextensionui": "^0.49.1",
+        "vscode-azureextensionui": "^0.49.3",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^4.1.1"
     },


### PR DESCRIPTION
So this is a bit more hacky than the proper solution which would be to update the `vscode-azureappservice` package again and pin `azureextensionui: v0.49.1`.  But this prevents us from having to release the npm package again.  I confirmed that this fixes the issue with the deployment slots.  You can see in the package-lock all of the other `v0.49.3` versions getting deleted.

Normally I'd advocate doing this through the proper channels, but it feels like it makes sense to upgrade the ui-package up to `v0.49.3` since a lot of the appservice tree items were actually being built on `v0.49.3` during their last test pass.