### PR TITLE
Update min supported version of VS Code to 1.66.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.24.3-alpha.3",
+    "version": "0.24.3-alpha.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.24.3-alpha.3",
+            "version": "0.24.3-alpha.4",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureappservice",
     "displayName": "Azure App Service",
     "description": "%appService.description%",
-    "version": "0.24.3-alpha.3",
+    "version": "0.24.3-alpha.4",
     "publisher": "ms-azuretools",
     "icon": "resources/WebApp.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/WebApp.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.63.0"
+        "vscode": "^1.66.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fixes #2272 

VS Code switched to Node 16.13.0 from 14.16.0 in the 1.66.0 update. Node 16.13.0 includes the randomUUID function which isn't present in Node 14.16.0.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/12476526/176773826-c59f41bc-3fd1-41f8-8aa9-b6d901d7fb99.png">
 

https://github.com/nodejs/node/commit/93a904d0ba