### PR TITLE
Fix `invalid java version 17` when create web app with java 17 runtime

### DIFF
--- a/src/commands/createWebApp/stacks/getJavaLinuxRuntime.ts
+++ b/src/commands/createWebApp/stacks/getJavaLinuxRuntime.ts
@@ -9,6 +9,8 @@ import { JavaContainers } from './models/WebAppStackModel';
 
 export function getJavaLinuxRuntime(javaMajorVersion: string, containerMinorVersion: AppStackMinorVersion<JavaContainers>): string | undefined {
     switch (javaMajorVersion) {
+        case '17':
+            return containerMinorVersion.stackSettings.linuxContainerSettings?.java17Runtime;
         case '11':
             return containerMinorVersion.stackSettings.linuxContainerSettings?.java11Runtime;
         case '8':

--- a/src/commands/createWebApp/stacks/models/WebAppStackModel.ts
+++ b/src/commands/createWebApp/stacks/models/WebAppStackModel.ts
@@ -35,5 +35,6 @@ export interface WindowsJavaContainerSettings extends CommonSettings {
 
 export interface LinuxJavaContainerSettings extends CommonSettings {
     java11Runtime?: string;
+    java17Runtime?: string;
     java8Runtime?: string;
 }


### PR DESCRIPTION
Fix `invalid java version 17` when create web app with java 17 runtime, fixes #2348 
- Update `LinuxJavaContainerSettings`, add `java17Runtime`, refers https://github.com/Azure/azure-functions-ux/pull/6529