### PR TITLE
Ensure `treeDataProvider` exists on created web app item

### DIFF
--- a/src/tree/SiteTreeItem.ts
+++ b/src/tree/SiteTreeItem.ts
@@ -6,7 +6,8 @@
 import { Site } from '@azure/arm-appservice';
 import { DeploymentsTreeItem, ParsedSite } from '@microsoft/vscode-azext-azureappservice';
 import { AppSettingsTreeItem } from '@microsoft/vscode-azext-azureappsettings';
-import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import { AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IActionContext, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import { ext } from '../extensionVariables';
 import { ISiteTreeItem } from './ISiteTreeItem';
 import { ResolvedWebAppResource } from './ResolvedWebAppResource';
 
@@ -17,8 +18,10 @@ export class SiteTreeItem extends AzExtParentTreeItem implements ISiteTreeItem {
     public appSettingsNode!: AppSettingsTreeItem;
     public deploymentsNode: DeploymentsTreeItem | undefined;
 
+    public treeDataProvider: AzExtTreeDataProvider;
     public constructor(parent: AzExtParentTreeItem, site: Site) {
         super(parent);
+        this.treeDataProvider = parent.treeDataProvider ?? ext.rgApi.appResourceTree;
         this.resolved = new ResolvedWebAppResource(parent.subscription, site);
     }
 


### PR DESCRIPTION
Fixes #2421 

> The error is caused by the tree data provider not bring present on the created web app item. This throws an error when it is refreshed inside of deploy.
> 
> It's undefined when the primary item of the create command is a `ResourceGroupsItem`, which doesn't (and shouldn't) have  the `treeDataProvider` property.
> 
> So this only reproduces when the entry point to create is  Right clicking the subscription, or App Service grouping items.