### PR TITLE
Remove Azure Account from extension dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -822,7 +822,6 @@
         "vscode-nls": "^4.1.1"
     },
     "extensionDependencies": [
-        "ms-vscode.azure-account",
         "ms-azuretools.vscode-azureresourcegroups"
     ],
     "enabledApiProposals": [


### PR DESCRIPTION
The Azure Resources extension A. can bring in AA if it needs, and B. no longer has AA as a dependency