### PR TITLE
Add Extension_Version setting for Linux apps as well

### DIFF
--- a/src/commands/createWebApp/WebAppCreateStep.ts
+++ b/src/commands/createWebApp/WebAppCreateStep.ts
@@ -147,6 +147,11 @@ export class WebAppCreateStep extends AzureWizardExecuteStep<IWebAppWizardContex
                 value: context.appInsightsComponent.connectionString
             });
 
+            appSettings.push({
+                name: 'ApplicationInsightsAgent_EXTENSION_VERSION',
+                value: context.newSiteOS === WebsiteOS.windows ? '~2' : '~3' // ~2 is for Windows, ~3 is for Linux
+            });
+
             // all these settings are set on the portal if AI is enabled for Windows apps
             if (context.newSiteOS === WebsiteOS.windows) {
                 appSettings.push(
@@ -157,10 +162,6 @@ export class WebAppCreateStep extends AzureWizardExecuteStep<IWebAppWizardContex
                     {
                         name: 'APPINSIGHTS_SNAPSHOTFEATURE_VERSION',
                         value: disabled
-                    },
-                    {
-                        name: 'ApplicationInsightsAgent_EXTENSION_VERSION',
-                        value: '~2'
                     },
                     {
                         name: 'DiagnosticServices_EXTENSION_VERSION',


### PR DESCRIPTION
Linux uses ~3, so just adding that extension_version setting in the app settings configuration.

To test this, you can just create a web app. For windows, it should be ~2, and for linux, ~3.