### PR TITLE
Add more domain name label scope related telemetry

### DIFF
--- a/src/WebAppResolver.ts
+++ b/src/WebAppResolver.ts
@@ -44,10 +44,13 @@ export class WebAppResolver implements AppResourceResolver {
             const site = this.siteCache.get(nonNullProp(resource, 'id').toLowerCase());
 
             const groupBy: string | undefined = getGlobalSetting<string>('groupBy', 'azureResourceGroups');
+            const hasDuplicateSiteName: boolean = (this.siteNameCounter.get(nonNullValueAndProp(site, 'name')) ?? 1) > 1;
+            context.telemetry.properties.hasDuplicateSiteName = String(hasDuplicateSiteName);
+
             return new ResolvedWebAppResource(subContext, nonNullValue(site), {
                 // Multiple sites with the same name could be displayed as long as they are in different locations
                 // To help distinguish these apps for our users, lookahead and determine if the location should be provided for duplicated site names
-                showLocationAsTreeItemDescription: groupBy === 'resourceType' && (this.siteNameCounter.get(nonNullValueAndProp(site, 'name')) ?? 1) > 1,
+                showLocationAsTreeItemDescription: groupBy === 'resourceType' && hasDuplicateSiteName,
             });
         });
     }

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -65,7 +65,7 @@ export async function deploy(actionContext: IActionContext, arg1?: vscode.Uri | 
     const correlationId: string = getRandomHexString();
     context.telemetry.properties.correlationId = correlationId;
     context.telemetry.properties.siteLocation = node.site.location;
-    context.telemetry.properties.domainNameLabelScope = await getDomainNameLabelScope(Object.assign(context, node.subscription), node.site.resourceGroup, node.site.siteName);
+    context.telemetry.properties.siteDomainNameLabelScope = await getDomainNameLabelScope(Object.assign(context, node.subscription), node.site.resourceGroup, node.site.siteName);
 
     // if we already got siteConfig, don't waste time getting it again
     siteConfig = siteConfig ? siteConfig : await client.getSiteConfig();


### PR DESCRIPTION
Add a telemetry point logging when a user has duplicate site names so we can figure out how often related code paths get triggered.

Fix a `siteDomainNameLabelScope` telemetry property name to match the step one in the shared packages.