### PR TITLE
Use ARM graph query to list app services and lazy load site payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.26.2",
+            "version": "0.26.3-alpha",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^5.0.0-beta.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.26.2",
+    "version": "0.26.3-alpha",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@azure/arm-appinsights": "^5.0.0-beta.4",
                 "@azure/arm-appservice": "^15.0.0",
+                "@azure/arm-resourcegraph": "^5.0.0-beta.3",
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/core-client": "^1.7.3",
                 "@azure/core-rest-pipeline": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureappservice",
     "displayName": "Azure App Service",
     "description": "%appService.description%",
-    "version": "0.26.2",
+    "version": "0.26.3-alpha",
     "publisher": "ms-azuretools",
     "icon": "resources/WebApp.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
@@ -773,8 +773,9 @@
         "webpack-cli": "^4.6.0"
     },
     "dependencies": {
-        "@azure/arm-appservice": "^15.0.0",
         "@azure/arm-appinsights": "^5.0.0-beta.4",
+        "@azure/arm-appservice": "^15.0.0",
+        "@azure/arm-resourcegraph": "^5.0.0-beta.3",
         "@azure/arm-resources": "^5.0.0",
         "@azure/core-client": "^1.7.3",
         "@azure/core-rest-pipeline": "^1.11.0",

--- a/src/WebAppResolver.ts
+++ b/src/WebAppResolver.ts
@@ -1,38 +1,57 @@
-import { type Site } from "@azure/arm-appservice";
-import { uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { ResourceGraphClient } from "@azure/arm-resourcegraph";
 import { callWithTelemetryAndErrorHandling, nonNullProp, nonNullValue, nonNullValueAndProp, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { type AppResource, type AppResourceResolver } from "@microsoft/vscode-azext-utils/hostapi";
 import { ResolvedWebAppResource } from "./tree/ResolvedWebAppResource";
-import { createWebSiteClient } from "./utils/azureClients";
 import { getGlobalSetting } from "./vsCodeConfig/settings";
 
+export type AppServiceQueryResult = {
+    id: string,
+    name: string,
+    type: string,
+    kind?: string,
+    location?: string,
+    subscriptionId?: string,
+    resourceGroup: string,
+    status?: string,
+    pricingTier?: string,
+    appServicePlanId?: string,
+    appType?: string
+}
 export class WebAppResolver implements AppResourceResolver {
 
     private siteCacheLastUpdated = 0;
-    private siteCache: Map<string, Site> = new Map<string, Site>();
+    private siteCache: Map<string, AppServiceQueryResult> = new Map<string, AppServiceQueryResult>();
     private siteNameCounter: Map<string, number> = new Map<string, number>();
     private listWebAppsTask: Promise<void> | undefined;
 
     public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedWebAppResource | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
-            const client = await createWebSiteClient({ ...context, ...subContext });
-
             if (this.siteCacheLastUpdated < Date.now() - 1000 * 3) {
+                const graphClient = new ResourceGraphClient(subContext.credentials);
+                const subscriptions = [subContext.subscriptionId];
+                const query = "resources|where type == 'microsoft.web/sites'\r\n| extend appServiceEnvironment = iff(properties.hostingEnvironmentId != 'null', extract('hostingEnvironments/([^/]+)', 1, tostring(properties.hostingEnvironmentId)), '')\r\n| extend appServicePlan = extract('serverfarms/([^/]+)', 1, tostring(properties.serverFarmId))\r\n| extend appServicePlanId = properties.serverFarmId\r\n| extend appServiceEnvironmentId = properties.hostingEnvironmentId\r\n| extend sku = tolower(properties.sku)\r\n| extend pricingTier = case(\r\nsku == 'free',\r\n'Free',\r\nsku == 'shared',\r\n'Shared',\r\nsku == 'dynamic',\r\n'Dynamic',\r\nsku == 'isolated',\r\n'Isolated',\r\nsku == 'isolatedv2' or sku == 'isolatedmv2',\r\n'Isolated V2',\r\nsku == 'premiumv2',\r\n'Premium V2',\r\nsku == 'premium',\r\n'Premium',\r\nsku == 'basic',\r\n'Basic',\r\nsku == 'elasticpremium',\r\n'Elastic Premium',\r\nsku == 'premiumv3' or sku == 'premium0v3' or sku == 'premiummv3',\r\n'Premium V3',\r\nsku == 'premiumv4' or sku == 'premiummv4',\r\n'Premium V4',\r\nsku == 'flexconsumption',\r\n'Flex Consumption',\r\n'Standard')\r\n| extend state = tolower(properties.state)\r\n| extend status = case(\r\nstate == 'stopped',\r\n'Stopped',\r\nstate == 'running',\r\n'Running',\r\n'Other')\r\n| extend appType = case(\r\nkind contains 'botapp',\r\n'Bot Service',\r\nkind contains 'api',\r\n'Api App',\r\nkind contains 'functionapp' and kind !contains 'workflowapp',\r\n'Function App',\r\nkind contains 'functionapp' and kind contains 'workflowapp',\r\n'Logic App (Standard)',\r\n'Web App')\r\n| project id, status, appType, appServicePlanId, pricingTier, location, subscriptionId, name, resourceGroup, kind, type, tags, appServiceEnvironmentId|where (type !~ ('dell.storage/filesystems'))|where (type !~ ('microsoft.weightsandbiases/instances'))|where (type !~ ('pinecone.vectordb/organizations'))|where (type !~ ('mongodb.atlas/organizations'))|where (type !~ ('commvault.contentstore/cloudaccounts'))|where (type !~ ('microsoft.liftrpilot/organizations'))|where (type !~ ('purestorage.block/storagepools/avsstoragecontainers'))|where (type !~ ('purestorage.block/reservations'))|where (type !~ ('purestorage.block/storagepools'))|where (type !~ ('solarwinds.observability/organizations'))|where (type !~ ('microsoft.agfoodplatform/farmbeats'))|where (type !~ ('microsoft.agricultureplatform/agriservices'))|where (type !~ ('microsoft.appsecurity/policies'))|where (type !~ ('microsoft.arc/allfairfax'))|where (type !~ ('microsoft.arc/all'))|where (type !~ ('microsoft.cdn/profiles/securitypolicies'))|where (type !~ ('microsoft.cdn/profiles/secrets'))|where (type !~ ('microsoft.cdn/profiles/rulesets'))|where (type !~ ('microsoft.cdn/profiles/rulesets/rules'))|where (type !~ ('microsoft.cdn/profiles/afdendpoints/routes'))|where (type !~ ('microsoft.cdn/profiles/origingroups'))|where (type !~ ('microsoft.cdn/profiles/origingroups/origins'))|where (type !~ ('microsoft.cdn/profiles/afdendpoints'))|where (type !~ ('microsoft.cdn/profiles/customdomains'))|where (type !~ ('microsoft.chaos/privateaccesses'))|where (type !~ ('microsoft.sovereign/transparencylogs'))|where (type !~ ('microsoft.compute/virtualmachineflexinstances'))|where (type !~ ('microsoft.compute/standbypoolinstance'))|where (type !~ ('microsoft.compute/computefleetscalesets'))|where (type !~ ('microsoft.compute/computefleetinstances'))|where (type !~ ('microsoft.containerservice/managedclusters/microsoft.kubernetesconfiguration/fluxconfigurations'))|where (type !~ ('microsoft.kubernetes/connectedclusters/microsoft.kubernetesconfiguration/fluxconfigurations'))|where (type !~ ('microsoft.containerservice/managedclusters/microsoft.kubernetesconfiguration/namespaces'))|where (type !~ ('microsoft.kubernetes/connectedclusters/microsoft.kubernetesconfiguration/namespaces'))|where (type !~ ('microsoft.containerservice/managedclusters/managednamespaces'))|where (type !~ ('microsoft.containerservice/managedclusters/microsoft.kubernetesconfiguration/extensions'))|where (type !~ ('microsoft.kubernetesconfiguration/extensions'))|where (type !~ ('microsoft.portalservices/extensions/deployments'))|where (type !~ ('microsoft.portalservices/extensions'))|where (type !~ ('microsoft.portalservices/extensions/slots'))|where (type !~ ('microsoft.portalservices/extensions/versions'))|where (type !~ ('microsoft.deviceregistry/devices'))|where (type !~ ('microsoft.deviceupdate/updateaccounts'))|where (type !~ ('microsoft.deviceupdate/updateaccounts/updates'))|where (type !~ ('microsoft.deviceupdate/updateaccounts/deviceclasses'))|where (type !~ ('microsoft.deviceupdate/updateaccounts/deployments'))|where (type !~ ('microsoft.deviceupdate/updateaccounts/agents'))|where (type !~ ('microsoft.deviceupdate/updateaccounts/activedeployments'))|where (type !~ ('private.devtunnels/tunnelplans'))|where (type !~ ('microsoft.discovery/datacontainers/dataassets'))|where (type !~ ('microsoft.documentdb/fleetspacepotentialdatabaseaccountswithlocations'))|where (type !~ ('microsoft.documentdb/fleetspacepotentialdatabaseaccounts'))|where (type !~ ('private.easm/workspaces'))|where (type !~ ('microsoft.workloads/epicvirtualinstances'))|where (type !~ ('microsoft.fairfieldgardens/provisioningresources'))|where (type !~ ('microsoft.fairfieldgardens/provisioningresources/provisioningpolicies'))|where (type !~ ('microsoft.healthmodel/healthmodels'))|where (type !~ ('microsoft.hybridcompute/machinessoftwareassurance'))|where (type !~ ('microsoft.hybridcompute/machinespaygo'))|where (type !~ ('microsoft.hybridcompute/machinesesu'))|where (type !~ ('microsoft.hybridcompute/machinessovereign'))|where (type !~ ('microsoft.hybridcompute/arcserverwithwac'))|where (type !~ ('microsoft.network/networkvirtualappliances'))|where (type !~ ('microsoft.network/virtualhubs')) or ((kind =~ ('routeserver')))|where (type !~ ('microsoft.devhub/iacprofiles'))|where (type !~ ('private.monitorgrafana/dashboards'))|where (type !~ ('microsoft.insights/diagnosticsettings'))|where not((type =~ ('microsoft.network/serviceendpointpolicies')) and ((kind =~ ('internal'))))|where (type !~ ('microsoft.resources/resourcegraphvisualizer'))|where (type !~ ('microsoft.orbital/l2connections'))|where (type !~ ('microsoft.orbital/groundstations'))|where (type !~ ('microsoft.orbital/edgesites'))|where (type !~ ('microsoft.recommendationsservice/accounts/modeling'))|where (type !~ ('microsoft.recommendationsservice/accounts/serviceendpoints'))|where (type !~ ('microsoft.recoveryservicesintd2/vaults'))|where (type !~ ('microsoft.recoveryservicesintd/vaults'))|where (type !~ ('microsoft.recoveryservicesbvtd2/vaults'))|where (type !~ ('microsoft.recoveryservicesbvtd/vaults'))|where (type !~ ('microsoft.billingbenefits/discounts'))|where (type !~ ('microsoft.billingbenefits/credits'))|where (type !~ ('microsoft.relationships/servicegrouprelationships'))|where (type !~ ('microsoft.resources/virtualsubscriptionsforresourcepicker'))|where (type !~ ('microsoft.resources/deletedresources'))|where (type !~ ('microsoft.deploymentmanager/rollouts'))|where (type !~ ('microsoft.features/featureprovidernamespaces/featureconfigurations'))|where (type !~ ('microsoft.saashub/cloudservices/hidden'))|where (type !~ ('microsoft.providerhub/providerregistrations'))|where (type !~ ('microsoft.providerhub/providerregistrations/customrollouts'))|where (type !~ ('microsoft.providerhub/providerregistrations/defaultrollouts'))|where (type !~ ('microsoft.edge/configurations'))|where (type !~ ('microsoft.storagediscovery/storagediscoveryworkspaces'))|where not((type =~ ('microsoft.synapse/workspaces/sqlpools')) and ((kind =~ ('v3'))))|where (type !~ ('microsoft.mission/virtualenclaves/workloads'))|where (type !~ ('microsoft.mission/virtualenclaves'))|where (type !~ ('microsoft.mission/communities/transithubs'))|where (type !~ ('microsoft.mission/virtualenclaves/enclaveendpoints'))|where (type !~ ('microsoft.mission/enclaveconnections'))|where (type !~ ('microsoft.mission/communities/communityendpoints'))|where (type !~ ('microsoft.mission/communities'))|where (type !~ ('microsoft.mission/catalogs'))|where (type !~ ('microsoft.mission/approvals'))|where (type !~ ('microsoft.workloads/insights'))|where (type !~ ('microsoft.cloudhealth/healthmodels'))|where (type !~ ('microsoft.connectedcache/enterprisemcccustomers/enterprisemcccachenodes'))|where not((type =~ ('microsoft.sql/servers')) and ((kind =~ ('v12.0,analytics'))))|where not((type =~ ('microsoft.sql/servers/databases')) and ((kind in~ ('system','v2.0,system','v12.0,system','v12.0,system,serverless','v12.0,user,datawarehouse,gen2,analytics'))))|project id,name,type,kind,location,subscriptionId,resourceGroup,tags,status,pricingTier,appServicePlanId,appType|sort by (tolower(tostring(name))) asc";
+                const queryRequest = {
+                    subscriptions,
+                    query
+                };
                 this.siteCacheLastUpdated = Date.now();
 
                 this.listWebAppsTask = new Promise((resolve, reject) => {
                     this.siteCache.clear();
                     this.siteNameCounter.clear();
 
-                    uiUtils.listAllIterator(client.webApps.list()).then((sites) => {
-                        for (const site of sites) {
-                            const siteName: string = nonNullProp(site, 'name');
-                            const count: number = (this.siteNameCounter.get(siteName) ?? 0) + 1;
-
-                            this.siteNameCounter.set(siteName, count);
-                            this.siteCache.set(nonNullProp(site, 'id').toLowerCase(), site);
-                        }
+                    graphClient.resources(queryRequest).then(response => {
+                        const record = response.data as Record<string, AppServiceQueryResult>;
+                        Object.values(record).forEach(data => {
+                            const count: number = (this.siteNameCounter.get(data.name) ?? 0) + 1;
+                            this.siteNameCounter.set(data.name, count);
+                            this.siteCache.set(data.id.toLowerCase(), data);
+                        });
                         resolve();
+
+
+
+
                     })
                         .catch((reason) => {
                             reject(reason);

--- a/src/commands/browseWebsite.ts
+++ b/src/commands/browseWebsite.ts
@@ -9,5 +9,5 @@ import { pickWebApp } from '../utils/pickWebApp';
 
 export async function browseWebsite(context: IActionContext, node?: ISiteTreeItem): Promise<void> {
     node ??= await pickWebApp(context);
-    await node.browse();
+    await node.browse(context);
 }

--- a/src/commands/createSlot.ts
+++ b/src/commands/createSlot.ts
@@ -24,7 +24,7 @@ export async function createSlot(context: IActionContext, node?: DeploymentSlots
 
     const createdSlot: SiteTreeItem = <SiteTreeItem>await node.createChild(context);
     showCreatedSlotMessage(context, createdSlot);
-
+    await node.parent.initSite(context);
     const client = await node.parent.site.createClient(context);
     // set the deploy source as the same as its production slot
     const siteConfig: SiteConfigResource = await client.getSiteConfig();

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -44,6 +44,7 @@ export async function deploy(actionContext: IActionContext, arg1?: vscode.Uri | 
             // if the user uses the deploy button, it's possible for the local node to be passed in, so we should reset it to undefined
             arg1 = undefined;
         } else {
+            await arg1.initSite(actionContext);
             client = await arg1.site.createClient(actionContext);
             // we can only get the siteConfig earlier if the entry point was a treeItem
             siteConfig = await client.getSiteConfig();
@@ -60,6 +61,7 @@ export async function deploy(actionContext: IActionContext, arg1?: vscode.Uri | 
     const node: SiteTreeItem = await getDeployNode(context, ext.rgApi.tree, arg1, arg2, () => ext.rgApi.pickAppResource(context, {
         filter: constants.webAppFilter
     }));
+    await node.initSite(context);
     client = await node.site.createClient(actionContext);
 
     const correlationId: string = getRandomHexString();

--- a/src/commands/deploy/showDeployCompletedMessage.ts
+++ b/src/commands/deploy/showDeployCompletedMessage.ts
@@ -31,7 +31,7 @@ export function showDeployCompletedMessage(originalContext: IActionContext, node
             if (result === AppServiceDialogResponses.viewOutput) {
                 ext.outputChannel.show();
             } else if (result === browseWebsiteBtn) {
-                await node.browse();
+                await node.browse(context);
             } else if (result === streamLogs) {
                 await startStreamingLogs(context, node);
             } else if (result === uploadSettingsBtn) {

--- a/src/commands/generateDeploymentScript.ts
+++ b/src/commands/generateDeploymentScript.ts
@@ -24,6 +24,7 @@ export async function generateDeploymentScript(context: IActionContext, node?: S
         node = nonNullValue(node);
 
         const resourceClient: ResourceManagementClient = await createResourceClient([context, node.subscription]);
+        await node.initSite(context);
         const client = await node.site.createClient(context);
         const tasks = Promise.all([
             resourceClient.resourceGroups.get(node.site.resourceGroup),

--- a/src/commands/logstream/enableFileLogging.ts
+++ b/src/commands/logstream/enableFileLogging.ts
@@ -20,12 +20,14 @@ export async function enableFileLogging(context: IEnableFileLoggingContext, node
         node ??= await pickWebApp(context);
     }
 
+
     if (node instanceof LogFilesTreeItem) {
         // If the entry point was the Log Files node, pass the parent as that's where the logic lives
         node = <SiteTreeItem>node.parent;
     }
 
     const siteNode: SiteTreeItem = node;
+    await siteNode.initSite(context);
 
     const isEnabled: boolean = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async p => {
         p.report({ message: localize('checkingDiag', 'Checking container diagnostics settings...') });

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -14,6 +14,8 @@ export async function startStreamingLogs(context: IActionContext, node?: SiteTre
         node = await pickWebApp({ ...context, suppressCreatePick: true });
     }
 
+    await node.initSite(context);
+
     const verifyLoggingEnabled: () => Promise<void> = async (): Promise<void> => {
         await enableFileLogging({ ...context, suppressAlreadyEnabledMessage: true }, node);
     };

--- a/src/commands/logstream/stopStreamingLogs.ts
+++ b/src/commands/logstream/stopStreamingLogs.ts
@@ -13,5 +13,6 @@ export async function stopStreamingLogs(context: IActionContext, node?: SiteTree
         node = await pickWebApp({ ...context, suppressCreatePick: true });
     }
 
+    await node.initSite(context);
     await appservice.stopStreamingLogs(node.site);
 }

--- a/src/commands/startSsh.ts
+++ b/src/commands/startSsh.ts
@@ -32,7 +32,7 @@ export const sshURL = 'root@127.0.0.1';
  */
 export async function startSsh(context: IActionContext, node?: SiteTreeItem): Promise<void> {
     node ??= await pickWebApp(context);
-
+    await node.initSite(context);
     const currentSshTerminal: sshTerminal | undefined = sshSessionsMap.get(node.site.fullName);
     if (currentSshTerminal) {
         if (currentSshTerminal.starting) {
@@ -53,6 +53,7 @@ export async function startSsh(context: IActionContext, node?: SiteTreeItem): Pr
 }
 
 async function startSshInternal(context: IActionContext, node: SiteTreeItem): Promise<void> {
+    await node.initSite(context);
     if (!node.site.isLinux) {
         throw new Error(localize('sshLinuxError', 'Azure SSH is only supported for Linux web apps.'));
     }
@@ -81,6 +82,7 @@ async function startSshInternal(context: IActionContext, node: SiteTreeItem): Pr
 }
 
 function connectToTunnelProxy(node: SiteTreeItem, tunnelProxy: TunnelProxy, port: number): void {
+    // site will be initialized by startSshInternal, so we can safely use it here
     const sshTerminalName: string = `${node.site.fullName} - SSH`;
     // -o StrictHostKeyChecking=no doesn't prompt for adding to hosts
     // -o "UserKnownHostsFile /dev/null" doesn't add host to known_user file

--- a/src/commands/startWebApp.ts
+++ b/src/commands/startWebApp.ts
@@ -11,7 +11,7 @@ import { pickWebApp } from "../utils/pickWebApp";
 
 export async function startWebApp(context: IActionContext, node?: SiteTreeItem): Promise<void> {
     node ??= await pickWebApp(context);
-
+    await node.initSite(context);
     const startingApp: string = localize('startingApp', 'Starting "{0}"...', node.site.fullName);
     const startedApp: string = localize('startedApp', '"{0}" has been started.', node.site.fullName);
 

--- a/src/commands/stopWebApp.ts
+++ b/src/commands/stopWebApp.ts
@@ -15,6 +15,7 @@ export async function stopWebApp(context: IActionContext, node?: SiteTreeItem): 
         node = await pickWebApp(context);
     }
 
+    await node.initSite(context);
     const client = await node.site.createClient(context);
     const stoppingApp: string = localize('stoppingApp', 'Stopping "{0}"...', node.site.fullName);
     const stoppedApp: string = localize('stoppedApp', '"{0}" has been stopped. App Service plan charges still apply.', node.site.fullName);

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -9,6 +9,7 @@ import { type SiteTreeItem } from '../tree/SiteTreeItem';
 
 export async function viewProperties(context: IActionContext, treeItem?: SiteTreeItem): Promise<void> {
     const node = nonNullValue(treeItem);
+    await node.initSite(context);
     const client = await node.site.createClient(context);
     await node.runWithTemporaryDescription(context, localize('retrievingProps', 'Retrieving properties...'), async () => {
         // `siteConfig` already exists on `node.site`, but has very limited properties for some reason. We want to get the full site config

--- a/src/tree/ISiteTreeItem.ts
+++ b/src/tree/ISiteTreeItem.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { type IActionContext } from "@microsoft/vscode-azext-utils";
+
 export interface ISiteTreeItem {
     defaultHostUrl: string;
     defaultHostName: string;
-    browse(): Promise<void>;
+    browse(context: IActionContext): Promise<void>;
 }

--- a/src/tree/SiteTreeItem.ts
+++ b/src/tree/SiteTreeItem.ts
@@ -57,6 +57,10 @@ export class SiteTreeItem extends AzExtParentTreeItem implements ISiteTreeItem {
         return this.resolved.site;
     }
 
+    public async initSite(context: IActionContext): Promise<void> {
+        return await this.resolved.initSite(context);
+    }
+
     public hasMoreChildrenImpl(): boolean {
         return this.resolved.hasMoreChildrenImpl();
     }
@@ -81,8 +85,8 @@ export class SiteTreeItem extends AzExtParentTreeItem implements ISiteTreeItem {
         return await this.resolved.deleteTreeItemImpl(context);
     }
 
-    public async browse(): Promise<void> {
-        return await this.resolved.browse();
+    public async browse(context: IActionContext): Promise<void> {
+        return await this.resolved.browse(context);
     }
 
     public async isHttpLogsEnabled(context: IActionContext): Promise<boolean> {

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type WebSiteManagementClient } from '@azure/arm-appservice';
+import { type ResourceGraphClient } from '@azure/arm-resourcegraph';
 import { type ResourceManagementClient } from '@azure/arm-resources';
-import { createAzureClient, type AzExtClientContext } from '@microsoft/vscode-azext-azureutils';
+import { createAzureClient, createAzureSubscriptionClient, type AzExtClientContext } from '@microsoft/vscode-azext-azureutils';
 
 // Lazy-load @azure packages to improve startup performance.
 // NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
@@ -15,4 +16,8 @@ export async function createWebSiteClient(clientContext: AzExtClientContext): Pr
 }
 export async function createResourceClient(clientContext: AzExtClientContext): Promise<ResourceManagementClient> {
     return createAzureClient(clientContext, (await import('@azure/arm-resources')).ResourceManagementClient);
+}
+
+export async function createResourceGraphClient(context: AzExtClientContext): Promise<ResourceGraphClient> {
+    return createAzureSubscriptionClient(context, (await import('@azure/arm-resourcegraph')).ResourceGraphClient);
 }

--- a/src/utils/javaUtils.ts
+++ b/src/utils/javaUtils.ts
@@ -80,6 +80,7 @@ export namespace javaUtils {
     }
 
     export async function configureJavaSEAppSettings(context: IActionContext, node: SiteTreeItem): Promise<StringDictionary | undefined> {
+        await node.initSite(context);
         const client = await node.site.createClient(context);
         const appSettings: StringDictionary = await client.listApplicationSettings();
         if (isJavaSERequiredPortConfigured(appSettings)) {


### PR DESCRIPTION
This pull request introduces several updates to the Azure App Service extension, including dependency additions, refactoring of the `WebAppResolver` class, and consistent initialization of site resources across various commands. These changes aim to enhance functionality, improve code maintainability, and ensure better handling of site data.

### Dependency Updates:
* Added `@azure/arm-resourcegraph` as a new dependency in `package.json` for querying resources using Azure Resource Graph.

### Refactoring of `WebAppResolver`:
* Replaced the `Site` type with `AppServiceDataModel` and introduced `AppServiceQueryModel` for handling site data more flexibly. Updated `WebAppResolver` to use Azure Resource Graph for fetching web app resources instead of the previous `createWebSiteClient` approach.

### Site Initialization Enhancements:
* Added calls to `node.initSite(context)` across various commands (`browseWebsite`, `createSlot`, `deploy`, `startSsh`, etc.) to ensure site resources are initialized before performing operations. This change improves consistency and avoids potential issues with uninitialized site data:
  - `browseWebsite` command updated to pass `context` to the `browse` method. [[1]](diffhunk://#diff-aab78f4fee4b707fe0d26444cd8a60a4d060ed5f6e0be579820869a591994371L12-R12) [[2]](diffhunk://#diff-82f5257d25e9a86a25f28470c6503ecd4c0785022ba5f95bb4922983b033805fR6-R11)
  - Commands like `createSlot`, `deploy`, `startWebApp`, and `stopWebApp` now initialize site resources before executing their main logic. [[1]](diffhunk://#diff-98e50f5599762e8becf9bb882068458d6cf4b6d2b7b2d57330443f45af8a8f0dL27-R27) [[2]](diffhunk://#diff-ed0d81595c753431c907d0d2a29e9cce17b1e4ebf0af0237c3e059416d6d7b62R47) [[3]](diffhunk://#diff-7de192c7352be78d92c645a274cd1d7818dabf3a90e51522cd37fe325d0cea75L14-R14) [[4]](diffhunk://#diff-6ee55edae566d8c06271503c9d89eb0c36c72079bffc256638a98d883d011191R18)
  - Log streaming commands (`startStreamingLogs`, `stopStreamingLogs`) and SSH commands (`startSsh`) also include site initialization for better reliability. [[1]](diffhunk://#diff-46a486d09fb4bbc63d524a8109e0a9ded70ce96d098766f4295c7ebec79bca9dR17-R18) [[2]](diffhunk://#diff-7460b25ec6fef2942da986dbb0a6dd8b64d96ad70310e73e000e5c69b777c178R16) [[3]](diffhunk://#diff-17f2964b06b30cc97e1028e8637e10917017302eeb697114d3e845d2ca20e61aL35-R35) [[4]](diffhunk://#diff-17f2964b06b30cc97e1028e8637e10917017302eeb697114d3e845d2ca20e61aR56)

### Updates to `ResolvedWebAppResource`:
* Refactored `ResolvedWebAppResource` to use `AppServiceDataModel` for site data handling. Introduced a protected `_site` property for encapsulation and updated related imports. [[1]](diffhunk://#diff-33dbbf31b6cdf6477373c8a791073499ee49d90cd7abbd5cc44d4e2ad4c6af4fL7-R9) [[2]](diffhunk://#diff-33dbbf31b6cdf6477373c8a791073499ee49d90cd7abbd5cc44d4e2ad4c6af4fR20) [[3]](diffhunk://#diff-33dbbf31b6cdf6477373c8a791073499ee49d90cd7abbd5cc44d4e2ad4c6af4fL37-R39)

### Version Update:
* Changed the extension version in `package.json` to `0.26.3-alpha`, indicating an alpha release with new features and updates.