### PR TITLE
Change the toggle slot setting name to be more clear

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -35,7 +35,7 @@
     "appService.appSettings.Download": "Download Remote Settings...",
     "appService.appSettings.Edit": "Edit...",
     "appService.appSettings.Rename": "Rename...",
-    "appService.appSettings.ToggleSlotSetting": "Toggle as Slot Setting",
+    "appService.appSettings.ToggleSlotSetting": "Switch Slot Setting",
     "appService.appSettings.Upload": "Upload Local Settings...",
     "appService.connectToGitHub": "Connect to GitHub Repository...",
     "appService.connections": "Array of web apps with its connections",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureappservice/issues/2759 by just making it slightly more clear.

Ideally we'd have a dynamic title, but that would require monkey patching a way to set the context on the app setting tree item.

Between this and the visible setting, should probably just add contexts to the tree item in the app settings package.