### PR TITLE
Upgrade @microsoft/vscode-azext-azureappservice to 4.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@azure/arm-resources": "^5.0.0",
                 "@azure/core-client": "^1.7.3",
                 "@azure/core-rest-pipeline": "^1.11.0",
-                "@microsoft/vscode-azext-azureappservice": "^4.1.0",
+                "@microsoft/vscode-azext-azureappservice": "^4.1.2",
                 "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
                 "@microsoft/vscode-azext-azureutils": "^4.0.1",
                 "@microsoft/vscode-azext-utils": "^4.0.2",
@@ -1585,9 +1585,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappservice": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-4.1.0.tgz",
-            "integrity": "sha512-vPHp682BPxWxuInJGPUFWoIFuy4OeOw62CmEzQsA4BLc1yNoDk1UgqzQBkh4UnCSHQB3RNt+cPn5Gzv0utf5Qw==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-4.1.2.tgz",
+            "integrity": "sha512-ro4/GAIbGJizfYGpwI/3J1EjxJoMtap8g8SttQBoJkj2WbETtMuHfDlnfRIa5cgjCtH8mTNlPTcKto09jGqqtw==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -749,7 +749,7 @@
         "@azure/arm-resources": "^5.0.0",
         "@azure/core-client": "^1.7.3",
         "@azure/core-rest-pipeline": "^1.11.0",
-        "@microsoft/vscode-azext-azureappservice": "^4.1.0",
+        "@microsoft/vscode-azext-azureappservice": "^4.1.2",
         "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
         "@microsoft/vscode-azext-azureutils": "^4.0.1",
         "@microsoft/vscode-azext-utils": "^4.0.2",


### PR DESCRIPTION
Updates `@microsoft/vscode-azext-azureappservice` from `4.1.0` to `4.1.2`.

## Bug fixes included in this upgrade

- **Fix incorrect falsey check for deployment status** ([vscode-azuretools#2213](https://github.com/microsoft/vscode-azuretools/pull/2213)) — An incorrect falsey check on the deployment status could cause deployment status to be misreported. This fixes the condition to properly check for null/undefined deployment status values.

- **Pre-populate web app name with resource group name in advanced creation** ([vscode-azuretools#2218](https://github.com/microsoft/vscode-azuretools/pull/2218)) — In the Advanced creation flow, the site name input box was always empty even when a new resource group had already been created. The input is now pre-populated with the resource group name when available. Fixes #2826.

## Other changes

- **Bump simple-git from 3.16.0 to 3.32.3** ([vscode-azuretools#2216](https://github.com/microsoft/vscode-azuretools/pull/2216)) — Security-related dependency update.
- **Bump minimatch** ([vscode-azuretools#2204](https://github.com/microsoft/vscode-azuretools/pull/2204)) — Dependency update.