### PR TITLE
Fix preDeployTask 'clean' failing with MSB1050 for multi-file folders

### DIFF
--- a/src/commands/deploy/dotnet/setPreDeployConfigForDotnet.ts
+++ b/src/commands/deploy/dotnet/setPreDeployConfigForDotnet.ts
@@ -53,7 +53,8 @@ export async function setPreDeployConfigForDotnet(context: IDeployContext, cspro
     }
 
     // do not overwrite any dotnet tasks the user already defined
-    let newTasks: tasks.ITask[] = generateDotnetTasks(subfolder);
+    const csprojRelativePath: string = path.relative(workspaceFspath, csprojFile);
+    let newTasks: tasks.ITask[] = generateDotnetTasks(csprojRelativePath);
     newTasks = newTasks.filter(t1 => !existingTasks.find(t2 => {
         return t1.label === t2.label;
     }));
@@ -72,10 +73,12 @@ async function tryGetTargetFramework(projFilePath: string): Promise<string | und
     return matches === null ? undefined : matches[1];
 }
 
-function generateDotnetTasks(subfolder: string): TaskDefinition[] {
-    // always use posix for debug config because it's committed to source control and works on all OS's
+function generateDotnetTasks(csprojRelativePath: string): TaskDefinition[] {
+    // Use the specific .csproj file path instead of the directory to avoid MSB1050
+    // when the folder contains multiple project or solution files.
+    // Always use posix for debug config because it's committed to source control and works on all OS's
     // eslint-disable-next-line no-template-curly-in-string
-    const cwd: string = path.posix.join('${workspaceFolder}', subfolder);
+    const projectPath: string = path.posix.join('${workspaceFolder}', csprojRelativePath.split(path.sep).join(path.posix.sep));
 
     const cleanTask: TaskDefinition = {
         label: cleanId,
@@ -83,7 +86,7 @@ function generateDotnetTasks(subfolder: string): TaskDefinition[] {
         type: "process",
         args: [
             'clean',
-            cwd,
+            projectPath,
             "/property:GenerateFullPaths=true",
             "/consoleloggerparameters:NoSummary"
         ],
@@ -96,7 +99,7 @@ function generateDotnetTasks(subfolder: string): TaskDefinition[] {
         type: "process",
         args: [
             'publish',
-            cwd,
+            projectPath,
             '--configuration',
             'Release',
             "/property:GenerateFullPaths=true",


### PR DESCRIPTION
## Problem

When auto-generating `.vscode/tasks.json` for .NET deployments, the extension passes the **directory path** (e.g., `${workspaceFolder}/src`) as the project argument to `dotnet clean` and `dotnet publish`. When that directory contains both a `.csproj` and a `.sln` file, MSBuild throws **MSB1050**: *"Specify which project or solution file to use because the folder contains more than one project or solution file."*

This was reported deploying the [CodeOptimizationsSampleApp](https://github.com/jkalis-MS/CodeOptimizationsSampleApp), which has both `Store.csproj` and `CodeOptimizationsSampleApp.sln` in its `src/` folder.

## Fix

Changed `generateDotnetTasks()` to pass the specific `.csproj` file path instead of the parent directory as the project argument.

**Before:** `dotnet clean ${workspaceFolder}/src` → MSB1050 ❌
**After:** `dotnet clean ${workspaceFolder}/src/Store.csproj` → ✅

Fixes #2841