### PR TITLE
Bump version after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## 0.27.0 - 2026-05-28
+
+### Overview
+This release introduces **container image deployment** for App Service, along with code optimization improvements and several bug fixes around deployment slots and disconnecting repos.
+
+### Added
+* [[2871](https://github.com/microsoft/vscode-azureappservice/pull/2871)] Support **deployment of container images** to App Service
+
+### Changed
+* [[2854](https://github.com/microsoft/vscode-azureappservice/pull/2854)] Skip the **code optimization quick pick** when fixing a code optimization via the command palette
+
+### Fixed
+* [[2860](https://github.com/microsoft/vscode-azureappservice/pull/2860)] Surface the missing warning when disconnecting a repo on a slot with no repo connected
+* [[2855](https://github.com/microsoft/vscode-azureappservice/pull/2855)] Check for **deployment slots** when disconnecting a repo
+* [[2849](https://github.com/microsoft/vscode-azureappservice/pull/2849)] Fix various **code optimization** bugs
+
+### Security
+* [[2859](https://github.com/microsoft/vscode-azureappservice/pull/2859)] Resolve npm security vulnerabilities via `npm audit fix`
+
+### Engineering
+* [[2874](https://github.com/microsoft/vscode-azureappservice/pull/2874)] Remove obsolete nightly .NET deploy test targets (3.1 / 5.0 / 6.0)
+* [[2865](https://github.com/microsoft/vscode-azureappservice/pull/2865)] Remove Shields.io badges from `README.md`
+
 ## 0.26.5 - 2026-03-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureappservice",
-    "version": "0.27.0",
+    "version": "0.27.1-alpha.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureappservice",
-            "version": "0.27.0",
+            "version": "0.27.1-alpha.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^5.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureappservice",
     "displayName": "Azure App Service",
     "description": "%appService.description%",
-    "version": "0.27.0",
+    "version": "0.27.1-alpha.0",
     "publisher": "ms-azuretools",
     "icon": "resources/WebApp.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
## Bump version after release

Bumps version in preparation for the next development cycle.

> ⚠️ **Do not merge until the upstream release PR has been merged and the extension has been published.**
> This PR depends on https://github.com/microsoft/vscode-azureappservice/pull/2881 — merge that first.

> 🤖 This PR was generated by GitHub Copilot. Please review all changes before merging.